### PR TITLE
Fix hex helper

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -42,7 +42,13 @@
 
 inline int AsHex(const char c)
 {
-   return c >= 'A' ? c - 'A' + 0xA : c - '0';
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return c - 'a' + 0xA;
+    if (c >= 'A' && c <= 'F')
+        return c - 'A' + 0xA;
+    return 0;
 }
 
 inline unsigned int Pow2Ceil(u16 n)


### PR DESCRIPTION
## Summary
- fix `AsHex` helper to correctly parse lowercase hex digits

## Testing
- `g++ -std=c++11 -Iplatforms/shared/dependencies/miniz -c src/common.h -o /tmp/common.o`

------
https://chatgpt.com/codex/tasks/task_e_686d8ab2bba48333ad05da82c75ada65