### PR TITLE
[debugger] Add Load Memory From Binary

### DIFF
--- a/platforms/shared/desktop/gui_debug_memeditor.cpp
+++ b/platforms/shared/desktop/gui_debug_memeditor.cpp
@@ -1851,6 +1851,16 @@ void MemEditor::SaveToBinaryFile(const char* file_path)
     }
 }
 
+void MemEditor::LoadFromBinaryFile(const char* file_path)
+{
+    FILE* file = fopen_utf8(file_path, "rb");
+    if (file)
+    {
+        fread(m_mem_data, m_mem_word, m_mem_size, file);
+        fclose(file);
+    }
+}
+
 void MemEditor::AddBookmark()
 {
     m_add_bookmark = true;

--- a/platforms/shared/desktop/gui_debug_memeditor.h
+++ b/platforms/shared/desktop/gui_debug_memeditor.h
@@ -76,6 +76,7 @@ public:
     void SetValueToSelection(int value);
     void SaveToTextFile(const char* file_path);
     void SaveToBinaryFile(const char* file_path);
+    void LoadFromBinaryFile(const char* file_path);
     void AddBookmark();
     void RemoveBookmarks();
     std::vector<Bookmark>* GetBookmarks();

--- a/platforms/shared/desktop/gui_debug_memory.cpp
+++ b/platforms/shared/desktop/gui_debug_memory.cpp
@@ -186,6 +186,11 @@ void gui_debug_memory_save_dump(const char* file_path, bool binary)
         mem_edit[current_mem_edit].SaveToTextFile(file_path);
 }
 
+void gui_debug_memory_load_dump(const char* file_path)
+{
+    mem_edit[current_mem_edit].LoadFromBinaryFile(file_path);
+}
+
 static void draw_tabs(void)
 {
     GeargrafxCore* core = emu_get_core();
@@ -240,6 +245,11 @@ static void memory_editor_menu(void)
         if (ImGui::MenuItem("Save Memory As Binary..."))
         {
             gui_file_dialog_save_memory_dump(true);
+        }
+
+        if (ImGui::MenuItem("Load Memory From Binary..."))
+        {
+            gui_file_dialog_load_memory_dump();
         }
 
         ImGui::EndMenu();

--- a/platforms/shared/desktop/gui_debug_memory.h
+++ b/platforms/shared/desktop/gui_debug_memory.h
@@ -61,6 +61,7 @@ EXTERN void gui_debug_memory_paste(void);
 EXTERN void gui_debug_memory_select_all(void);
 EXTERN void gui_debug_memory_goto(int editor, int address);
 EXTERN void gui_debug_memory_save_dump(const char* file_path, bool binary);
+EXTERN void gui_debug_memory_load_dump(const char* file_path);
 EXTERN bool gui_debug_memory_select_range(int editor, int start_address, int end_address);
 EXTERN void gui_debug_memory_set_selection_value(int editor, u8 value);
 EXTERN void gui_debug_memory_add_bookmark(int editor, int address, const char* name);

--- a/platforms/shared/desktop/gui_filedialogs.cpp
+++ b/platforms/shared/desktop/gui_filedialogs.cpp
@@ -57,6 +57,7 @@ enum FileDialogID
     FileDialog_SaveBackground,
     FileDialog_SaveMemoryDumpBinary,
     FileDialog_SaveMemoryDumpText,
+    FileDialog_LoadMemoryDumpBinary,
     FileDialog_SaveDisassemblerFull,
     FileDialog_SaveDisassemblerVisible,
     FileDialog_SaveLog,
@@ -256,6 +257,16 @@ void gui_file_dialog_save_memory_dump(bool binary)
     FileDialogID id = binary ? FileDialog_SaveMemoryDumpBinary : FileDialog_SaveMemoryDumpText;
     SDL_DialogFileFilter filters[] = { { "Memory Dump Files", binary ? "bin" : "txt" } };
     SDL_ShowSaveFileDialog(file_dialog_callback, (void*)(intptr_t)id, application_sdl_window, filters, 1, NULL);
+}
+
+void gui_file_dialog_load_memory_dump()
+{
+    if (!begin_dialog())
+        return;
+
+    SDL_DialogFileFilter filters[] = { { "Memory Dump Files", "bin" } };
+    const char* default_path = config_emulator.last_open_path.empty() ? NULL : config_emulator.last_open_path.c_str();
+    SDL_ShowOpenFileDialog(file_dialog_callback, (void*)(intptr_t)FileDialog_LoadMemoryDumpBinary, application_sdl_window, filters, 1, default_path, false);
 }
 
 void gui_file_dialog_save_disassembler(bool full)
@@ -472,6 +483,11 @@ static void process_dialog_result(FileDialogID id, const char* path)
         case FileDialog_SaveMemoryDumpText:
         {
             gui_debug_memory_save_dump(path, false);
+            break;
+        }
+        case FileDialog_LoadMemoryDumpBinary:
+        {
+            gui_debug_memory_load_dump(path);
             break;
         }
         case FileDialog_SaveDisassemblerFull:

--- a/platforms/shared/desktop/gui_filedialogs.h
+++ b/platforms/shared/desktop/gui_filedialogs.h
@@ -43,6 +43,7 @@ EXTERN void gui_file_dialog_save_sprite(int vdc, int index);
 EXTERN void gui_file_dialog_save_all_sprites(int vdc);
 EXTERN void gui_file_dialog_save_background(int vdc);
 EXTERN void gui_file_dialog_save_memory_dump(bool binary);
+EXTERN void gui_file_dialog_load_memory_dump(void);
 EXTERN void gui_file_dialog_save_disassembler(bool full);
 EXTERN void gui_file_dialog_save_log(void);
 EXTERN void gui_file_dialog_save_debug_settings(void);


### PR DESCRIPTION
Hi! First off, thanks for Geargrafx. I’ve been using it extensively for PC Engine CD-ROM² ROM hacking work, and the debugger has been extremely useful.  Fantastic emu.

This PR adds a small debugger feature, a third entry "Load Memory From Binary" in the memory editor,  to load binary data directly into memory.

An example would be: I make a save state and dump the card RAM.  Then I can patch the bin different ways with a hex editor/other tools, then to test I just load the save state and load the patched bin to card RAM.

I found this helpful when testing different RAM states without having to restart the game (or load a save state before a CD read if I patched the CD image itself) then play/fast-forward back to a specific test location each time.