### PR TITLE
[debugger] Add BAT addr and row/col to bg viewer tooltip

### DIFF
--- a/platforms/shared/desktop/gui_debug_huc6270_background.cpp
+++ b/platforms/shared/desktop/gui_debug_huc6270_background.cpp
@@ -183,6 +183,18 @@ void gui_debug_window_huc6270_background(int vdc)
                 ImGui::SameLine();
                 ImGui::TextColored(white, "%01X", color_table);
 
+                ImGui::TextColored(magenta, "BAT ADDRESS  ");
+                ImGui::SameLine();
+                ImGui::TextColored(white, "%03X", i);
+
+                ImGui::TextColored(magenta, "ROW");
+                ImGui::SameLine();
+                ImGui::TextColored(white, "%d", y);
+                ImGui::SameLine();
+                ImGui::TextColored(magenta, "COL");
+                ImGui::SameLine();
+                ImGui::TextColored(white, "%d", x);
+
                 ImGui::PopFont();
 
                 ImGui::EndTooltip();


### PR DESCRIPTION
Hi.  Another small addition, if you're interested.  The tooltip when mousing over a tile in the background viewer shows these infos under the tile graphics:
TILE INDEX
TILE ADDRESS           (vram addr)
COLOR TABLE            (bg palette)

I found that a lot of times I wanted to know the location of the BAT entry itself.  To do that I had to count the number of tiles horizontally and vertically to compute the address of the tile BAT entry in VRAM.

So I just put these infos at the bottom of the toolip.  Makes it less tedious.
BAT ADDRESS         (addr of BAT entry in VRAM)
ROW xx  COL yy      (zero-based)

Example in the game I'm working on:
<img width="1869" height="1834" alt="bg-viewer-tooltip" src="https://github.com/user-attachments/assets/5a523156-04fa-42c1-bc9d-4fd4ee071011" />
