### PR TITLE
[debugger] Add physical memory breakpoint types

### DIFF
--- a/platforms/shared/desktop/application.cpp
+++ b/platforms/shared/desktop/application.cpp
@@ -148,6 +148,8 @@ int application_init(const char* rom_file, const char* symbol_file, bool force_f
         emu_mcp_start();
     }
 
+    application_refocus_window();
+
     return 0;
 }
 

--- a/platforms/shared/desktop/gui_debug.cpp
+++ b/platforms/shared/desktop/gui_debug.cpp
@@ -247,6 +247,7 @@ void gui_debug_load_settings(const char* file_path)
         file.read((char*)&bp.range, sizeof(bool));
         breakpoints->push_back(bp);
     }
+    processor->RefreshBreakpointFlags();
 
     file.read((char*)&emu_debug_irq_breakpoints, sizeof(bool));
 

--- a/platforms/shared/desktop/gui_debug.cpp
+++ b/platforms/shared/desktop/gui_debug.cpp
@@ -64,6 +64,7 @@ void gui_debug_reset(void)
 {
     gui_debug_disassembler_reset();
     gui_debug_memory_reset();
+    gui_debug_reset_breakpoints();
     gui_debug_reset_symbols();
 }
 
@@ -133,8 +134,7 @@ void gui_debug_windows(void)
     }
 }
 
-static const char* GGDEBUG_MAGIC_V2 = "GGDEBUG2";
-static const char* GGDEBUG_MAGIC_V3 = "GGDEBUG3";
+static const char* GGDEBUG_MAGIC = "GGDEBUG3";
 static const int GGDEBUG_MAGIC_LEN = 8;
 
 void gui_debug_save_settings(const char* file_path)
@@ -146,7 +146,7 @@ void gui_debug_save_settings(const char* file_path)
         return;
     }
 
-    file.write(GGDEBUG_MAGIC_V3, GGDEBUG_MAGIC_LEN);
+    file.write(GGDEBUG_MAGIC, GGDEBUG_MAGIC_LEN);
 
     GeargrafxCore* core = emu_get_core();
     HuC6280* processor = core->GetHuC6280();
@@ -202,9 +202,7 @@ void gui_debug_load_settings(const char* file_path)
     char magic[8];
     file.read(magic, GGDEBUG_MAGIC_LEN);
 
-    bool is_v2 = memcmp(magic, GGDEBUG_MAGIC_V2, GGDEBUG_MAGIC_LEN) == 0;
-    bool is_v3 = memcmp(magic, GGDEBUG_MAGIC_V3, GGDEBUG_MAGIC_LEN) == 0;
-    if (!is_v2 && !is_v3)
+    if (memcmp(magic, GGDEBUG_MAGIC, GGDEBUG_MAGIC_LEN) != 0)
     {
         Log("Invalid debug settings file: %s", file_path);
         file.close();
@@ -223,24 +221,8 @@ void gui_debug_load_settings(const char* file_path)
         HuC6280::GG_Breakpoint bp{};
         file.read((char*)&bp.enabled, sizeof(bool));
         file.read((char*)&bp.type, sizeof(int));
-
-        if (is_v2)
-        {
-            u16 address1 = 0;
-            u16 address2 = 0;
-
-            file.read((char*)&address1, sizeof(u16));
-            file.read((char*)&address2, sizeof(u16));
-
-            bp.address1 = address1;
-            bp.address2 = address2;
-        }
-        else
-        {
-            file.read((char*)&bp.address1, sizeof(u32));
-            file.read((char*)&bp.address2, sizeof(u32));
-        }
-
+        file.read((char*)&bp.address1, sizeof(u32));
+        file.read((char*)&bp.address2, sizeof(u32));
         file.read((char*)&bp.read, sizeof(bool));
         file.read((char*)&bp.write, sizeof(bool));
         file.read((char*)&bp.execute, sizeof(bool));

--- a/platforms/shared/desktop/gui_debug.cpp
+++ b/platforms/shared/desktop/gui_debug.cpp
@@ -151,12 +151,12 @@ void gui_debug_save_settings(const char* file_path)
     GeargrafxCore* core = emu_get_core();
     HuC6280* processor = core->GetHuC6280();
 
-    std::vector<HuC6280::GG_Breakpoint>* breakpoints = processor->GetBreakpoints();
+    const std::vector<HuC6280::GG_Breakpoint>* breakpoints = processor->GetBreakpoints();
     int bp_count = (int)breakpoints->size();
     file.write((const char*)&bp_count, sizeof(int));
     for (int i = 0; i < bp_count; i++)
     {
-        HuC6280::GG_Breakpoint& bp = (*breakpoints)[i];
+        const HuC6280::GG_Breakpoint& bp = (*breakpoints)[i];
         file.write((const char*)&bp.enabled, sizeof(bool));
         file.write((const char*)&bp.type, sizeof(int));
         file.write((const char*)&bp.address1, sizeof(u32));
@@ -215,7 +215,7 @@ void gui_debug_load_settings(const char* file_path)
     processor->ResetBreakpoints();
     int bp_count = 0;
     file.read((char*)&bp_count, sizeof(int));
-    std::vector<HuC6280::GG_Breakpoint>* breakpoints = processor->GetBreakpoints();
+    std::vector<HuC6280::GG_Breakpoint> breakpoints;
     for (int i = 0; i < bp_count; i++)
     {
         HuC6280::GG_Breakpoint bp{};
@@ -227,9 +227,9 @@ void gui_debug_load_settings(const char* file_path)
         file.read((char*)&bp.write, sizeof(bool));
         file.read((char*)&bp.execute, sizeof(bool));
         file.read((char*)&bp.range, sizeof(bool));
-        breakpoints->push_back(bp);
+        breakpoints.push_back(bp);
     }
-    processor->RefreshBreakpointFlags();
+    processor->SetBreakpoints(breakpoints);
 
     file.read((char*)&emu_debug_irq_breakpoints, sizeof(bool));
 

--- a/platforms/shared/desktop/gui_debug.cpp
+++ b/platforms/shared/desktop/gui_debug.cpp
@@ -64,7 +64,6 @@ void gui_debug_reset(void)
 {
     gui_debug_disassembler_reset();
     gui_debug_memory_reset();
-    gui_debug_reset_breakpoints();
     gui_debug_reset_symbols();
 }
 
@@ -134,7 +133,8 @@ void gui_debug_windows(void)
     }
 }
 
-static const char* GGDEBUG_MAGIC = "GGDEBUG2";
+static const char* GGDEBUG_MAGIC_V2 = "GGDEBUG2";
+static const char* GGDEBUG_MAGIC_V3 = "GGDEBUG3";
 static const int GGDEBUG_MAGIC_LEN = 8;
 
 void gui_debug_save_settings(const char* file_path)
@@ -146,7 +146,7 @@ void gui_debug_save_settings(const char* file_path)
         return;
     }
 
-    file.write(GGDEBUG_MAGIC, GGDEBUG_MAGIC_LEN);
+    file.write(GGDEBUG_MAGIC_V3, GGDEBUG_MAGIC_LEN);
 
     GeargrafxCore* core = emu_get_core();
     HuC6280* processor = core->GetHuC6280();
@@ -159,8 +159,8 @@ void gui_debug_save_settings(const char* file_path)
         HuC6280::GG_Breakpoint& bp = (*breakpoints)[i];
         file.write((const char*)&bp.enabled, sizeof(bool));
         file.write((const char*)&bp.type, sizeof(int));
-        file.write((const char*)&bp.address1, sizeof(u16));
-        file.write((const char*)&bp.address2, sizeof(u16));
+        file.write((const char*)&bp.address1, sizeof(u32));
+        file.write((const char*)&bp.address2, sizeof(u32));
         file.write((const char*)&bp.read, sizeof(bool));
         file.write((const char*)&bp.write, sizeof(bool));
         file.write((const char*)&bp.execute, sizeof(bool));
@@ -201,7 +201,10 @@ void gui_debug_load_settings(const char* file_path)
 
     char magic[8];
     file.read(magic, GGDEBUG_MAGIC_LEN);
-    if (memcmp(magic, GGDEBUG_MAGIC, GGDEBUG_MAGIC_LEN) != 0)
+
+    bool is_v2 = memcmp(magic, GGDEBUG_MAGIC_V2, GGDEBUG_MAGIC_LEN) == 0;
+    bool is_v3 = memcmp(magic, GGDEBUG_MAGIC_V3, GGDEBUG_MAGIC_LEN) == 0;
+    if (!is_v2 && !is_v3)
     {
         Log("Invalid debug settings file: %s", file_path);
         file.close();
@@ -217,11 +220,27 @@ void gui_debug_load_settings(const char* file_path)
     std::vector<HuC6280::GG_Breakpoint>* breakpoints = processor->GetBreakpoints();
     for (int i = 0; i < bp_count; i++)
     {
-        HuC6280::GG_Breakpoint bp;
+        HuC6280::GG_Breakpoint bp{};
         file.read((char*)&bp.enabled, sizeof(bool));
         file.read((char*)&bp.type, sizeof(int));
-        file.read((char*)&bp.address1, sizeof(u16));
-        file.read((char*)&bp.address2, sizeof(u16));
+
+        if (is_v2)
+        {
+            u16 address1 = 0;
+            u16 address2 = 0;
+
+            file.read((char*)&address1, sizeof(u16));
+            file.read((char*)&address2, sizeof(u16));
+
+            bp.address1 = address1;
+            bp.address2 = address2;
+        }
+        else
+        {
+            file.read((char*)&bp.address1, sizeof(u32));
+            file.read((char*)&bp.address2, sizeof(u32));
+        }
+
         file.read((char*)&bp.read, sizeof(bool));
         file.read((char*)&bp.write, sizeof(bool));
         file.read((char*)&bp.execute, sizeof(bool));

--- a/platforms/shared/desktop/gui_debug_disassembler.cpp
+++ b/platforms/shared/desktop/gui_debug_disassembler.cpp
@@ -457,59 +457,70 @@ static const BreakpointTypeInfo k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOI
     { HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM,        "CD RAM   ", "CD RAM",      4 },
     { HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM,       "BRAM     ", "BRAM",        3 },
 };
-static_assert(
-    sizeof(k_breakpoint_type_info) / sizeof(k_breakpoint_type_info[0]) ==
-    HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT,
-    "k_breakpoint_type_info has wrong number of BP types"
-);
+
+static const int k_breakpoint_type_info_count =
+    (int)(sizeof(k_breakpoint_type_info) / sizeof(k_breakpoint_type_info[0]));
 
 static const BreakpointTypeInfo* get_breakpoint_type_info(int type)
 {
-    for (auto& e : k_breakpoint_type_info)
+    for (int type_index = 0; type_index < k_breakpoint_type_info_count; type_index++)
     {
-        if (e.type == type)
-            return &e;
+        if (k_breakpoint_type_info[type_index].type == type)
+            return &k_breakpoint_type_info[type_index];
     }
     return NULL;
 }
 
-static std::vector<BreakpointTypeInfo> get_breakpoint_types()
+static void add_breakpoint_type_entry(const BreakpointTypeInfo** entries, int& count, HuC6280::GG_Breakpoint_Type type)
 {
-    std::vector<BreakpointTypeInfo> entries;
-    entries.reserve(HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT);
+    entries[count] = &k_breakpoint_type_info[type];
+    count++;
+}
+
+static int get_breakpoint_types(const BreakpointTypeInfo** entries)
+{
+    int count = 0;
 
     GeargrafxCore* core = emu_get_core();
     Memory* memory = core->GetMemory();
     Media* media = core->GetMedia();
 
-    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS]);
-    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM]);
-    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM]);
-    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER]);
-    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER]);
-    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM]);
-    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE]);
+    add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS);
+    add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM);
+    add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM);
+    add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER);
+    add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER);
+    add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM);
+    add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE);
 
     if (IsValidPointer(media->GetROM()))
-        entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_ROM]);
+    {
+        add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_ROM);
+    }
 
     if (memory->GetCardRAMSize() > 0)
-        entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM]);
+    {
+        add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM);
+    }
 
     if (memory->GetCDROMRAMSize() > 0)
-        entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM]);
+    {
+        add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM);
+    }
 
     if (memory->IsBackupRamEnabled())
-        entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM]);
+    {
+        add_breakpoint_type_entry(entries, count, HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM);
+    }
 
-    return entries;
+    return count;
 }
 
 static void breakpoint_address_string(const HuC6280::GG_Breakpoint* brk, char* out, size_t out_size)
 {
     int digits = 4;
 
-    auto info = get_breakpoint_type_info(brk->type);
+    const BreakpointTypeInfo* info = get_breakpoint_type_info(brk->type);
     if (IsValidPointer(info))
         digits = info->address_digits;
 
@@ -551,38 +562,47 @@ static void draw_breakpoints_content(void)
 
     ImGui::Separator();
 
-    auto type_entries = get_breakpoint_types();
+    const BreakpointTypeInfo* type_entries[HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT];
+    int type_count = get_breakpoint_types(type_entries);
 
-    const char* current_label = type_entries[0].combo_label;
+    const char* current_label = type_entries[0]->combo_label;
     bool current_type_available = false;
 
-    for (auto& e : type_entries)
+    for (int type_index = 0; type_index < type_count; type_index++)
     {
-        if (e.type == new_breakpoint_type)
+        const BreakpointTypeInfo* entry = type_entries[type_index];
+
+        if (entry->type == new_breakpoint_type)
         {
-            current_label = e.combo_label;
+            current_label = entry->combo_label;
             current_type_available = true;
         }
     }
 
     if (!current_type_available)
     {
-        new_breakpoint_type = type_entries[0].type;
-        current_label = type_entries[0].combo_label;
+        new_breakpoint_type = type_entries[0]->type;
+        current_label = type_entries[0]->combo_label;
     }
 
     ImGui::PushItemWidth(120);
 
     if (ImGui::BeginCombo("Type##type", current_label))
     {
-        for (auto& entry : type_entries)
+        for (int type_index = 0; type_index < type_count; type_index++)
         {
-            bool selected = (new_breakpoint_type == entry.type);
+            const BreakpointTypeInfo* entry = type_entries[type_index];
+            bool selected = (new_breakpoint_type == entry->type);
 
-            if (ImGui::Selectable(entry.combo_label, selected))
-                new_breakpoint_type = entry.type;
+            if (ImGui::Selectable(entry->combo_label, selected))
+            {
+                new_breakpoint_type = entry->type;
+            }
+
             if (selected)
+            {
                 ImGui::SetItemDefaultFocus();
+            }
         }
         ImGui::EndCombo();
     }
@@ -630,10 +650,14 @@ static void draw_breakpoints_content(void)
     ImGui::Checkbox("Read", &new_breakpoint_read);
 
     if (new_breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM)
+    {
         ImGui::Checkbox("Write", &new_breakpoint_write);
+    }
 
     if (breakpoint_type_supports_execute(new_breakpoint_type))
+    {
         ImGui::Checkbox("Execute", &new_breakpoint_execute);
+    }
 
     if (ImGui::Button("Add##add", ImVec2(85, 0)))
     {
@@ -660,7 +684,9 @@ static void draw_breakpoints_content(void)
         float width = ImGui::CalcTextSize(address_text).x;
 
         if (width > max_address_width)
+        {
             max_address_width = width;
+        }
     }
 
     for (long unsigned int b = 0; b < breakpoints->size(); b++)
@@ -707,7 +733,7 @@ static void draw_breakpoints_content(void)
         ImGui::PopFont();
 
         ImGui::SameLine();
-        auto info = get_breakpoint_type_info(brk->type);
+        const BreakpointTypeInfo* info = get_breakpoint_type_info(brk->type);
         const char* list_label = IsValidPointer(info) ? info->list_label : "???      ";
 
         ImGui::TextColored(brk->enabled ? red : gray, "%s", list_label);
@@ -721,7 +747,7 @@ static void draw_breakpoints_content(void)
         ImGui::SameLine();
         ImGui::SetCursorPosX(address_x + max_address_width + ImGui::CalcTextSize(" ").x);
 
-        ImGui::PushStyleColor(ImGuiCol_Text, brk->enabled&& brk->read ? orange : gray);
+        ImGui::PushStyleColor(ImGuiCol_Text, brk->enabled && brk->read ? orange : gray);
         if (ImGui::SmallButton("R##read_btn"))
         {
             cpu->ToggleBreakpointAccess((int)b, HuC6280::HuC6280_BREAKPOINT_ACCESS_READ);
@@ -763,7 +789,9 @@ static void draw_breakpoints_content(void)
 
         GG_Disassembler_Record* record = NULL;
         if (brk->type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS)
+        {
             record = emu_get_core()->GetMemory()->GetDisassemblerRecord((u16)brk->address1);
+        }
 
         bool symbol_shown = false;
 
@@ -771,7 +799,9 @@ static void draw_breakpoints_content(void)
         {
             DebugSymbol* symbol = fixed_symbols[record->bank][brk->address1];
             if (!IsValidPointer(symbol))
+            {
                 symbol = dynamic_symbols[record->bank][brk->address1];
+            }
             if (IsValidPointer(symbol))
             {
                 ImGui::SameLine(0, 0);
@@ -808,7 +838,9 @@ static void draw_breakpoints_content(void)
     ImGui::PopFont();
 
     if (remove >= 0)
+    {
         cpu->RemoveBreakpointAt(remove);
+    }
 
     ImGui::EndChild();
     ImGui::Columns(1);

--- a/platforms/shared/desktop/gui_debug_disassembler.cpp
+++ b/platforms/shared/desktop/gui_debug_disassembler.cpp
@@ -66,8 +66,8 @@ static std::vector<DisassemblerLine> disassembler_lines(0x10000);
 static std::vector<DisassemblerBookmark> bookmarks;
 static int selected_address = -1;
 static int selected_bank = -1;
-static int new_breakpoint_type = HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM;
-static char new_breakpoint_buffer[10] = "";
+static int new_breakpoint_type = HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS;
+static char new_breakpoint_buffer[32] = "";
 static bool new_breakpoint_read = false;
 static bool new_breakpoint_write = false;
 static bool new_breakpoint_execute = true;
@@ -93,6 +93,7 @@ static void draw_context_menu(DisassemblerLine* line);
 static void add_cdrom_symbols();
 static void add_symbol(const char* line);
 static void add_breakpoint(int type);
+static bool breakpoint_type_supports_execute(int type);
 static void request_goto_address(u16 addr);
 static bool is_return_instruction(u8 opcode);
 static void replace_symbols(DisassemblerLine* line, const char* jump_color, const char* operand_color, const char* auto_color, const char* original_color);
@@ -270,8 +271,8 @@ void gui_debug_toggle_breakpoint(void)
 {
     if (selected_address >= 0)
     {
-        if (emu_get_core()->GetHuC6280()->IsBreakpoint(HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM, selected_address))
-            emu_get_core()->GetHuC6280()->RemoveBreakpoint(HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM, selected_address);
+        if (emu_get_core()->GetHuC6280()->IsBreakpoint(HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, selected_address))
+            emu_get_core()->GetHuC6280()->RemoveBreakpoint(HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, selected_address);
         else
             emu_get_core()->GetHuC6280()->AddBreakpoint(selected_address);
     }
@@ -434,7 +435,138 @@ static void draw_controls(void)
     ImGui::TextColored(emu_is_debug_idle() ? red : green, emu_is_debug_idle() ? "   PAUSED" : "   RUNNING");
 }
 
-static const char* k_breakpoint_types[] = { "ROM/RAM ", "VRAM    ", "PALETTE ", "6270    ", "6260    " };
+static void toggle_breakpoint_flag(HuC6280::GG_Breakpoint* brk, bool* flag)
+{
+    if (!brk->enabled)
+    {
+        brk->enabled = true;
+        *flag = true;
+        return;
+    }
+
+    int active_flags = 0;
+
+    if (brk->read)
+        active_flags++;
+
+    if (brk->write && brk->type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM)
+        active_flags++;
+
+    if (brk->execute && breakpoint_type_supports_execute(brk->type))
+    {
+        active_flags++;
+    }
+
+    if (*flag && active_flags <= 1)
+    {
+        *flag = false;
+        brk->enabled = false;
+        return;
+    }
+
+    *flag = !*flag;
+}
+
+struct BreakpointTypeInfo
+{
+    HuC6280::GG_Breakpoint_Type type;
+    const char* list_label;
+    const char* combo_label;
+    int address_digits;
+};
+
+static const BreakpointTypeInfo k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT] =
+{
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS,      "CPU ADDR ", "CPU ADDR",    4 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM,             "VRAM     ", "VRAM",        4 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM,      "PALETTE  ", "Palette RAM", 3 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER, "6270     ", "HuC6270 Reg", 2 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER, "6260     ", "HuC6260 Reg", 2 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM,             "WRAM     ", "WRAM",        4 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE,        "ZP       ", "Zero Page",   2 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_ROM,              "ROM      ", "ROM",         6 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM,         "CARD RAM ", "CARD RAM",    5 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM,        "CD RAM   ", "CD RAM",      4 },
+    { HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM,       "BRAM     ", "BRAM",        3 },
+};
+static_assert(
+    sizeof(k_breakpoint_type_info) / sizeof(k_breakpoint_type_info[0]) ==
+    HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT,
+    "k_breakpoint_type_info has wrong number of BP types"
+);
+
+static const BreakpointTypeInfo* get_breakpoint_type_info(int type)
+{
+    for (auto& e : k_breakpoint_type_info)
+    {
+        if (e.type == type)
+            return &e;
+    }
+    return NULL;
+}
+
+static std::vector<BreakpointTypeInfo> get_breakpoint_types()
+{
+    std::vector<BreakpointTypeInfo> entries;
+    entries.reserve(HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT);
+
+    GeargrafxCore* core = emu_get_core();
+    Memory* memory = core->GetMemory();
+    Media* media = core->GetMedia();
+
+    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS]);
+    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM]);
+    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM]);
+    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER]);
+    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER]);
+    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM]);
+    entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE]);
+
+    if (IsValidPointer(media->GetROM()))
+        entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_ROM]);
+
+    if (memory->GetCardRAMSize() > 0)
+        entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM]);
+
+    if (memory->GetCDROMRAMSize() > 0)
+        entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM]);
+
+    if (memory->IsBackupRamEnabled())
+        entries.push_back(k_breakpoint_type_info[HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM]);
+
+    return entries;
+}
+
+static void breakpoint_address_string(HuC6280::GG_Breakpoint* brk, char* out, size_t out_size)
+{
+    int digits = 4;
+
+    auto info = get_breakpoint_type_info(brk->type);
+    if (IsValidPointer(info))
+        digits = info->address_digits;
+
+    if (brk->range)
+    {
+        snprintf(out, out_size, "%0*X-%0*X", digits, brk->address1, digits, brk->address2);
+    }
+    else
+    {
+        snprintf(out, out_size, "%0*X", digits, brk->address1);
+    }
+}
+
+static void dummy_button(const char* label)
+{
+    ImVec2 size = ImGui::CalcTextSize(label);
+    const ImGuiStyle& style = ImGui::GetStyle();
+
+    size.x += style.FramePadding.x * 2.0f;
+    size.y = 0.0f;
+
+    ImGui::Dummy(size);
+}
+
+static int previous_breakpoint_type = new_breakpoint_type;
 
 static void draw_breakpoints_content(void)
 {
@@ -451,11 +583,62 @@ static void draw_breakpoints_content(void)
 
     ImGui::Separator();
 
-    ImGui::PushItemWidth(120);
-    ImGui::Combo("Type##type", &new_breakpoint_type, "ROM/RAM\0VRAM\0Palette RAM\0HuC6270 Reg\0HuC6260 Reg\0");
+    auto type_entries = get_breakpoint_types();
 
-    ImGui::PushItemWidth(85);
-    if (ImGui::InputTextWithHint("##add_breakpoint", "XXXX-XXXX", new_breakpoint_buffer, IM_ARRAYSIZE(new_breakpoint_buffer), ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_EnterReturnsTrue))
+    const char* current_label = type_entries[0].combo_label;
+    bool current_type_available = false;
+
+    for (auto& e : type_entries)
+    {
+        if (e.type == new_breakpoint_type)
+        {
+            current_label = e.combo_label;
+            current_type_available = true;
+        }
+    }
+
+    if (!current_type_available)
+    {
+        new_breakpoint_type = type_entries[0].type;
+        current_label = type_entries[0].combo_label;
+    }
+
+    ImGui::PushItemWidth(120);
+
+    if (ImGui::BeginCombo("Type##type", current_label))
+    {
+        for (auto& entry : type_entries)
+        {
+            bool selected = (new_breakpoint_type == entry.type);
+
+            if (ImGui::Selectable(entry.combo_label, selected))
+                new_breakpoint_type = entry.type;
+            if (selected)
+                ImGui::SetItemDefaultFocus();
+        }
+        ImGui::EndCombo();
+    }
+
+    if (previous_breakpoint_type != new_breakpoint_type)
+    {
+        new_breakpoint_read = new_breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS;
+        new_breakpoint_write = false;
+        new_breakpoint_execute =
+            (new_breakpoint_type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS ||
+                new_breakpoint_type == HuC6280::HuC6280_BREAKPOINT_TYPE_ROM);
+
+        previous_breakpoint_type = new_breakpoint_type;
+    }
+
+    ImGui::PopItemWidth();
+
+    ImGui::PushItemWidth(120);
+    if (ImGui::InputTextWithHint(
+        "##add_breakpoint",
+        "ADDR[-ADDR]",
+        new_breakpoint_buffer,
+        IM_ARRAYSIZE(new_breakpoint_buffer),
+        ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_EnterReturnsTrue))
     {
         add_breakpoint(new_breakpoint_type);
     }
@@ -465,9 +648,11 @@ static void draw_breakpoints_content(void)
         ImGui::SetTooltip("Use hex XXXX format for single addresses or XXXX-XXXX for address ranges");
 
     ImGui::Checkbox("Read", &new_breakpoint_read);
-    ImGui::Checkbox("Write", &new_breakpoint_write);
 
-    if (new_breakpoint_type == HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM)
+    if (new_breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM)
+        ImGui::Checkbox("Write", &new_breakpoint_write);
+
+    if (breakpoint_type_supports_execute(new_breakpoint_type))
         ImGui::Checkbox("Execute", &new_breakpoint_execute);
 
     if (ImGui::Button("Add##add", ImVec2(85, 0)))
@@ -481,16 +666,41 @@ static void draw_breakpoints_content(void)
     ImGui::PushFont(gui_default_font);
 
     int remove = -1;
+    int move_up = -1;
+    int move_down = -1;
     std::vector<HuC6280::GG_Breakpoint>* breakpoints = emu_get_core()->GetHuC6280()->GetBreakpoints();
+
+    float max_address_width = 0.0f;
+    char address_text[32];
+    for (long unsigned int b = 0; b < breakpoints->size(); b++)
+    {
+        HuC6280::GG_Breakpoint* brk = &(*breakpoints)[b];
+
+        breakpoint_address_string(brk, address_text, sizeof(address_text));
+
+        float width = ImGui::CalcTextSize(address_text).x;
+
+        if (width > max_address_width)
+            max_address_width = width;
+    }
 
     for (long unsigned int b = 0; b < breakpoints->size(); b++)
     {
         HuC6280::GG_Breakpoint* brk = &(*breakpoints)[b];
 
-        ImGui::PushID(10000 + b);
-        if (ImGui::SmallButton("X"))
+        ImGui::PushID((int)b);
+
+        ImGui::PushFont(gui_material_icons_font);
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2.0f, 1.0f));
+        ImVec2 bp_icon_btn_size = ImGui::CalcTextSize(ICON_MD_KEYBOARD_ARROW_UP);
+        bp_icon_btn_size.x += ImGui::GetStyle().FramePadding.x * 2.0f;
+        bp_icon_btn_size.y += ImGui::GetStyle().FramePadding.y * 2.0f;
+
+        if (ImGui::Button("X##remove", bp_icon_btn_size))
         {
            remove = b;
+           ImGui::PopStyleVar();
+           ImGui::PopFont();
            ImGui::PopID();
            continue;
         }
@@ -501,16 +711,13 @@ static void draw_breakpoints_content(void)
             ImGui::EndTooltip();
         }
 
-        ImGui::PopID();
+        ImGui::SameLine(0, 2);
 
-        ImGui::SameLine();
-
-        ImGui::PushID(20000 + b);
-        if (ImGui::SmallButton(brk->enabled ? "-" : "+"))
+        if (ImGui::Button(brk->enabled ? "-##toggle_enabled" : "+##toggle_enabled", bp_icon_btn_size))
         {
             brk->enabled = !brk->enabled;
+            emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
         }
-        ImGui::PopID();
         if (ImGui::IsItemHovered())
         {
             ImGui::BeginTooltip();
@@ -518,26 +725,86 @@ static void draw_breakpoints_content(void)
             ImGui::EndTooltip();
         }
 
-        ImGui::SameLine(); ImGui::TextColored(brk->enabled ? red : gray, "%s", k_breakpoint_types[brk->type]); ImGui::SameLine(0, 0);
+        ImGui::SameLine(0, 2);
+        if (b == 0) ImGui::BeginDisabled();
+        if (ImGui::Button(ICON_MD_KEYBOARD_ARROW_UP "##move_up", bp_icon_btn_size))
+            move_up = (int)b;
+        if (b == 0) ImGui::EndDisabled();
 
-        if ((*breakpoints)[b].range)
-            ImGui::TextColored(brk->enabled ? cyan : gray, "%04X-%04X", brk->address1, brk->address2);
-        else
-            ImGui::TextColored(brk->enabled ? cyan : gray, "%04X", brk->address1);
+        ImGui::SameLine(0, 2);
+        if (b == breakpoints->size() - 1) ImGui::BeginDisabled();
+        if (ImGui::Button(ICON_MD_KEYBOARD_ARROW_DOWN "##move_down", bp_icon_btn_size))
+            move_down = (int)b;
+        if (b == breakpoints->size() - 1) ImGui::EndDisabled();
 
-        ImGui::SameLine(0, 0); ImGui::TextColored(brk->enabled && brk->read ? orange : gray, " R");
-        ImGui::SameLine(0, 2); ImGui::TextColored(brk->enabled && brk->write ? orange : gray, "W");
+        ImGui::PopStyleVar();
+        ImGui::PopFont();
 
-        if (brk->type == HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM)
+        ImGui::SameLine();
+        auto info = get_breakpoint_type_info(brk->type);
+        const char* list_label = IsValidPointer(info) ? info->list_label : "???      ";
+
+        ImGui::TextColored(brk->enabled ? red : gray, "%s", list_label);
+        ImGui::SameLine(0, 0);
+
+        float address_x = ImGui::GetCursorPosX();
+
+        breakpoint_address_string(brk, address_text, sizeof(address_text));
+        ImGui::TextColored(brk->enabled ? cyan : gray, "%s", address_text);
+
+        ImGui::SameLine();
+        ImGui::SetCursorPosX(address_x + max_address_width + ImGui::CalcTextSize(" ").x);
+
+        ImGui::PushStyleColor(ImGuiCol_Text, brk->enabled&& brk->read ? orange : gray);
+        if (ImGui::SmallButton("R##read_btn"))
         {
-            ImGui::SameLine(0, 2); ImGui::TextColored(brk->enabled && brk->execute ? orange : gray, "X");
+            toggle_breakpoint_flag(brk, &brk->read);
+            emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
+        }
+        ImGui::PopStyleColor();
+
+        if (brk->type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM)
+        {
+            ImGui::SameLine(0, 2);
+            ImGui::PushStyleColor(ImGuiCol_Text, brk->enabled && brk->write ? orange : gray);
+            if (ImGui::SmallButton("W##write_btn"))
+            {
+                toggle_breakpoint_flag(brk, &brk->write);
+                emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
+            }
+            ImGui::PopStyleColor();
+        }
+        else
+        {
+
+            ImGui::SameLine(0, 2);
+            dummy_button("W");
         }
 
-        GG_Disassembler_Record* record = emu_get_core()->GetMemory()->GetDisassemblerRecord(brk->address1);
+        if (breakpoint_type_supports_execute(brk->type))
+        {
+            ImGui::SameLine(0, 2);
+            ImGui::PushStyleColor(ImGuiCol_Text, brk->enabled && brk->execute ? orange : gray);
+            if (ImGui::SmallButton("X##exec_btn"))
+            {
+                toggle_breakpoint_flag(brk, &brk->execute);
+                emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
+            }
+            ImGui::PopStyleColor();
+        }
+        else
+        {
+            ImGui::SameLine(0, 2);
+            dummy_button("X");
+        }
+
+        GG_Disassembler_Record* record = NULL;
+        if (brk->type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS)
+            record = emu_get_core()->GetMemory()->GetDisassemblerRecord((u16)brk->address1);
 
         bool symbol_shown = false;
 
-        if (!brk->range && (brk->type == HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM) && IsValidPointer(record))
+        if (!brk->range && (brk->type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS) && IsValidPointer(record))
         {
             DebugSymbol* symbol = fixed_symbols[record->bank][brk->address1];
             if (!IsValidPointer(symbol))
@@ -556,7 +823,10 @@ static void draw_breakpoints_content(void)
             }
         }
 
-        if (!symbol_shown && brk->execute && IsValidPointer(record))
+        if (!symbol_shown &&
+            brk->execute &&
+            (brk->type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS) &&
+            IsValidPointer(record))
         {
             ImGui::SameLine(0, 0);
             ImGui::PushStyleColor(ImGuiCol_Text, brk->enabled ? white : gray);
@@ -568,13 +838,22 @@ static void draw_breakpoints_content(void)
             ImGui::SameLine(0, 0);
             ImGui::TextColored(brk->enabled ? violet : gray, " %s", k_register_names[brk->address1]);
         }
+
+        ImGui::PopID();
     }
 
     ImGui::PopFont();
 
+    if (move_up > 0)
+        std::swap((*breakpoints)[move_up], (*breakpoints)[move_up - 1]);
+
+    if (move_down >= 0 && move_down < (int)breakpoints->size() - 1)
+        std::swap((*breakpoints)[move_down], (*breakpoints)[move_down + 1]);
+
     if (remove >= 0)
     {
         breakpoints->erase(breakpoints->begin() + remove);
+        emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
     }
 
     ImGui::EndChild();
@@ -693,7 +972,9 @@ static void prepare_drawable_lines(void)
             {
                 HuC6280::GG_Breakpoint* brk = &(*breakpoints)[b];
 
-                if (brk->execute && (brk->address1 == i))
+                if (brk->type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS &&
+                    brk->execute &&
+                    brk->address1 == (u32)i)
                 {
                     line.is_breakpoint = true;
                     break;
@@ -1084,17 +1365,31 @@ static void add_symbol(const char* line)
     }
 }
 
+static bool breakpoint_type_supports_execute(int type)
+{
+    return type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS ||
+        type == HuC6280::HuC6280_BREAKPOINT_TYPE_ROM ||
+        type == HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM ||
+        type == HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM;
+}
+
 static void add_breakpoint(int type)
 {
     bool read = new_breakpoint_read;
     bool write = new_breakpoint_write;
     bool execute = new_breakpoint_execute;
 
-    if (type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM)
+    if (!breakpoint_type_supports_execute(type))
     {
         if (!read && !write)
             return;
         execute = false;
+    }
+    else if (type == HuC6280::HuC6280_BREAKPOINT_TYPE_ROM)
+    {
+        if (!read && !execute)
+            return;
+        write = false;
     }
 
     if (emu_get_core()->GetHuC6280()->AddBreakpoint(type, new_breakpoint_buffer, read, write, execute))
@@ -1807,7 +2102,7 @@ void gui_debug_window_call_stack(void)
             {
                 if (ImGui::Selectable("Add Breakpoint"))
                 {
-                    if (!emu_get_core()->GetHuC6280()->IsBreakpoint(HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM, entry.dest))
+                    if (!emu_get_core()->GetHuC6280()->IsBreakpoint(HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, entry.dest))
                         emu_get_core()->GetHuC6280()->AddBreakpoint(entry.dest);
                 }
 
@@ -1996,7 +2291,7 @@ void gui_debug_window_symbols(void)
                 {
                     if (ImGui::Selectable("Add Breakpoint"))
                     {
-                        if (!emu_get_core()->GetHuC6280()->IsBreakpoint(HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM, symbol->address))
+                        if (!emu_get_core()->GetHuC6280()->IsBreakpoint(HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, symbol->address))
                             emu_get_core()->GetHuC6280()->AddBreakpoint(symbol->address);
                     }
 

--- a/platforms/shared/desktop/gui_debug_disassembler.cpp
+++ b/platforms/shared/desktop/gui_debug_disassembler.cpp
@@ -639,11 +639,15 @@ static void draw_breakpoints_content(void)
         ImGui::TextUnformatted("Examples: 8000, 8000-8FFF");
         ImGui::Separator();
         ImGui::TextUnformatted("The valid range depends on the selected type:");
-        ImGui::TextUnformatted("CPU, WRAM, VRAM, CD RAM: 0000-FFFF");
+        ImGui::TextUnformatted("CPU, CD RAM: 0000-FFFF");
+        ImGui::TextUnformatted("WRAM, VRAM: 0000-7FFF");
         ImGui::TextUnformatted("ROM: 000000-27FFFF");
         ImGui::TextUnformatted("Card RAM: 00000-2FFFF");
-        ImGui::TextUnformatted("Palette RAM, BRAM: 000-7FF");
-        ImGui::TextUnformatted("Zero page, VDC/VCE registers: 00-FF");
+        ImGui::TextUnformatted("Palette RAM: 000-1FF");
+        ImGui::TextUnformatted("BRAM: 000-7FF");
+        ImGui::TextUnformatted("Zero page: 00-FF");
+        ImGui::TextUnformatted("VDC registers: 00-13");
+        ImGui::TextUnformatted("VCE registers: 00-06");
         ImGui::EndTooltip();
     }
 

--- a/platforms/shared/desktop/gui_debug_disassembler.cpp
+++ b/platforms/shared/desktop/gui_debug_disassembler.cpp
@@ -613,7 +613,19 @@ static void draw_breakpoints_content(void)
     ImGui::PopItemWidth();
 
     if (ImGui::IsItemHovered())
-        ImGui::SetTooltip("Use hex XXXX format for single addresses or XXXX-XXXX for address ranges");
+    {
+        ImGui::BeginTooltip();
+        ImGui::TextUnformatted("Enter a hex address or address range.");
+        ImGui::TextUnformatted("Examples: 8000, 8000-8FFF");
+        ImGui::Separator();
+        ImGui::TextUnformatted("The valid range depends on the selected type:");
+        ImGui::TextUnformatted("CPU, WRAM, VRAM, CD RAM: 0000-FFFF");
+        ImGui::TextUnformatted("ROM: 000000-27FFFF");
+        ImGui::TextUnformatted("Card RAM: 00000-2FFFF");
+        ImGui::TextUnformatted("Palette RAM, BRAM: 000-7FF");
+        ImGui::TextUnformatted("Zero page, VDC/VCE registers: 00-FF");
+        ImGui::EndTooltip();
+    }
 
     ImGui::Checkbox("Read", &new_breakpoint_read);
 

--- a/platforms/shared/desktop/gui_debug_disassembler.cpp
+++ b/platforms/shared/desktop/gui_debug_disassembler.cpp
@@ -516,6 +516,46 @@ static int get_breakpoint_types(const BreakpointTypeInfo** entries)
     return count;
 }
 
+static const char* breakpoint_type_range_text(int type)
+{
+    switch (type)
+    {
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS:
+            return "0000-FFFF (16-bit logical)";
+
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM:
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM:
+            return "0000-7FFF";
+
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM:
+            return "0000-FFFF";
+
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM:
+            return "000-1FF";
+
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER:
+            return "00-13";
+
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER:
+            return "00-06";
+
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE:
+            return "00-FF";
+
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_ROM:
+            return "000000-27FFFF";
+
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM:
+            return "00000-2FFFF";
+
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM:
+            return "000-7FF";
+
+        default:
+            return "";
+    }
+}
+
 static void breakpoint_address_string(const HuC6280::GG_Breakpoint* brk, char* out, size_t out_size)
 {
     int digits = 4;
@@ -638,16 +678,12 @@ static void draw_breakpoints_content(void)
         ImGui::TextUnformatted("Enter a hex address or address range.");
         ImGui::TextUnformatted("Examples: 8000, 8000-8FFF");
         ImGui::Separator();
-        ImGui::TextUnformatted("The valid range depends on the selected type:");
-        ImGui::TextUnformatted("CPU, CD RAM: 0000-FFFF");
-        ImGui::TextUnformatted("WRAM, VRAM: 0000-7FFF");
-        ImGui::TextUnformatted("ROM: 000000-27FFFF");
-        ImGui::TextUnformatted("Card RAM: 00000-2FFFF");
-        ImGui::TextUnformatted("Palette RAM: 000-1FF");
-        ImGui::TextUnformatted("BRAM: 000-7FF");
-        ImGui::TextUnformatted("Zero page: 00-FF");
-        ImGui::TextUnformatted("VDC registers: 00-13");
-        ImGui::TextUnformatted("VCE registers: 00-06");
+        ImGui::TextUnformatted("Available type ranges:");
+        for (int type_index = 0; type_index < type_count; type_index++)
+        {
+            const BreakpointTypeInfo* entry = type_entries[type_index];
+            ImGui::Text("%s: %s", entry->combo_label, breakpoint_type_range_text(entry->type));
+        }
         ImGui::EndTooltip();
     }
 

--- a/platforms/shared/desktop/gui_debug_disassembler.cpp
+++ b/platforms/shared/desktop/gui_debug_disassembler.cpp
@@ -435,38 +435,6 @@ static void draw_controls(void)
     ImGui::TextColored(emu_is_debug_idle() ? red : green, emu_is_debug_idle() ? "   PAUSED" : "   RUNNING");
 }
 
-static void toggle_breakpoint_flag(HuC6280::GG_Breakpoint* brk, bool* flag)
-{
-    if (!brk->enabled)
-    {
-        brk->enabled = true;
-        *flag = true;
-        return;
-    }
-
-    int active_flags = 0;
-
-    if (brk->read)
-        active_flags++;
-
-    if (brk->write && brk->type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM)
-        active_flags++;
-
-    if (brk->execute && breakpoint_type_supports_execute(brk->type))
-    {
-        active_flags++;
-    }
-
-    if (*flag && active_flags <= 1)
-    {
-        *flag = false;
-        brk->enabled = false;
-        return;
-    }
-
-    *flag = !*flag;
-}
-
 struct BreakpointTypeInfo
 {
     HuC6280::GG_Breakpoint_Type type;
@@ -537,7 +505,7 @@ static std::vector<BreakpointTypeInfo> get_breakpoint_types()
     return entries;
 }
 
-static void breakpoint_address_string(HuC6280::GG_Breakpoint* brk, char* out, size_t out_size)
+static void breakpoint_address_string(const HuC6280::GG_Breakpoint* brk, char* out, size_t out_size)
 {
     int digits = 4;
 
@@ -666,15 +634,14 @@ static void draw_breakpoints_content(void)
     ImGui::PushFont(gui_default_font);
 
     int remove = -1;
-    int move_up = -1;
-    int move_down = -1;
-    std::vector<HuC6280::GG_Breakpoint>* breakpoints = emu_get_core()->GetHuC6280()->GetBreakpoints();
+    HuC6280* cpu = emu_get_core()->GetHuC6280();
+    const std::vector<HuC6280::GG_Breakpoint>* breakpoints = cpu->GetBreakpoints();
 
     float max_address_width = 0.0f;
     char address_text[32];
     for (long unsigned int b = 0; b < breakpoints->size(); b++)
     {
-        HuC6280::GG_Breakpoint* brk = &(*breakpoints)[b];
+        const HuC6280::GG_Breakpoint* brk = &(*breakpoints)[b];
 
         breakpoint_address_string(brk, address_text, sizeof(address_text));
 
@@ -686,13 +653,13 @@ static void draw_breakpoints_content(void)
 
     for (long unsigned int b = 0; b < breakpoints->size(); b++)
     {
-        HuC6280::GG_Breakpoint* brk = &(*breakpoints)[b];
+        const HuC6280::GG_Breakpoint* brk = &(*breakpoints)[b];
 
         ImGui::PushID((int)b);
 
         ImGui::PushFont(gui_material_icons_font);
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2.0f, 1.0f));
-        ImVec2 bp_icon_btn_size = ImGui::CalcTextSize(ICON_MD_KEYBOARD_ARROW_UP);
+        ImVec2 bp_icon_btn_size = ImGui::CalcTextSize("X");
         bp_icon_btn_size.x += ImGui::GetStyle().FramePadding.x * 2.0f;
         bp_icon_btn_size.y += ImGui::GetStyle().FramePadding.y * 2.0f;
 
@@ -715,8 +682,7 @@ static void draw_breakpoints_content(void)
 
         if (ImGui::Button(brk->enabled ? "-##toggle_enabled" : "+##toggle_enabled", bp_icon_btn_size))
         {
-            brk->enabled = !brk->enabled;
-            emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
+            cpu->SetBreakpointEnabled((int)b, !brk->enabled);
         }
         if (ImGui::IsItemHovered())
         {
@@ -724,18 +690,6 @@ static void draw_breakpoints_content(void)
             ImGui::Text(brk->enabled ? "Disable breakpoint" : "Enable breakpoint");
             ImGui::EndTooltip();
         }
-
-        ImGui::SameLine(0, 2);
-        if (b == 0) ImGui::BeginDisabled();
-        if (ImGui::Button(ICON_MD_KEYBOARD_ARROW_UP "##move_up", bp_icon_btn_size))
-            move_up = (int)b;
-        if (b == 0) ImGui::EndDisabled();
-
-        ImGui::SameLine(0, 2);
-        if (b == breakpoints->size() - 1) ImGui::BeginDisabled();
-        if (ImGui::Button(ICON_MD_KEYBOARD_ARROW_DOWN "##move_down", bp_icon_btn_size))
-            move_down = (int)b;
-        if (b == breakpoints->size() - 1) ImGui::EndDisabled();
 
         ImGui::PopStyleVar();
         ImGui::PopFont();
@@ -758,8 +712,7 @@ static void draw_breakpoints_content(void)
         ImGui::PushStyleColor(ImGuiCol_Text, brk->enabled&& brk->read ? orange : gray);
         if (ImGui::SmallButton("R##read_btn"))
         {
-            toggle_breakpoint_flag(brk, &brk->read);
-            emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
+            cpu->ToggleBreakpointAccess((int)b, HuC6280::HuC6280_BREAKPOINT_ACCESS_READ);
         }
         ImGui::PopStyleColor();
 
@@ -769,8 +722,7 @@ static void draw_breakpoints_content(void)
             ImGui::PushStyleColor(ImGuiCol_Text, brk->enabled && brk->write ? orange : gray);
             if (ImGui::SmallButton("W##write_btn"))
             {
-                toggle_breakpoint_flag(brk, &brk->write);
-                emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
+                cpu->ToggleBreakpointAccess((int)b, HuC6280::HuC6280_BREAKPOINT_ACCESS_WRITE);
             }
             ImGui::PopStyleColor();
         }
@@ -787,8 +739,7 @@ static void draw_breakpoints_content(void)
             ImGui::PushStyleColor(ImGuiCol_Text, brk->enabled && brk->execute ? orange : gray);
             if (ImGui::SmallButton("X##exec_btn"))
             {
-                toggle_breakpoint_flag(brk, &brk->execute);
-                emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
+                cpu->ToggleBreakpointAccess((int)b, HuC6280::HuC6280_BREAKPOINT_ACCESS_EXECUTE);
             }
             ImGui::PopStyleColor();
         }
@@ -844,17 +795,8 @@ static void draw_breakpoints_content(void)
 
     ImGui::PopFont();
 
-    if (move_up > 0)
-        std::swap((*breakpoints)[move_up], (*breakpoints)[move_up - 1]);
-
-    if (move_down >= 0 && move_down < (int)breakpoints->size() - 1)
-        std::swap((*breakpoints)[move_down], (*breakpoints)[move_down + 1]);
-
     if (remove >= 0)
-    {
-        breakpoints->erase(breakpoints->begin() + remove);
-        emu_get_core()->GetHuC6280()->RefreshBreakpointFlags();
-    }
+        cpu->RemoveBreakpointAt(remove);
 
     ImGui::EndChild();
     ImGui::Columns(1);
@@ -966,11 +908,11 @@ static void prepare_drawable_lines(void)
             snprintf(line.name_enhanced, 64, "%s", line.record->name);
             line.tooltip[0] = 0;
 
-            std::vector<HuC6280::GG_Breakpoint>* breakpoints = emu_get_core()->GetHuC6280()->GetBreakpoints();
+            const std::vector<HuC6280::GG_Breakpoint>* breakpoints = emu_get_core()->GetHuC6280()->GetBreakpoints();
 
             for (long unsigned int b = 0; b < breakpoints->size(); b++)
             {
-                HuC6280::GG_Breakpoint* brk = &(*breakpoints)[b];
+                const HuC6280::GG_Breakpoint* brk = &(*breakpoints)[b];
 
                 if (brk->type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS &&
                     brk->execute &&

--- a/platforms/shared/desktop/gui_debug_disassembler.cpp
+++ b/platforms/shared/desktop/gui_debug_disassembler.cpp
@@ -735,7 +735,7 @@ static void draw_breakpoints_content(void)
 
         ImGui::PushID((int)b);
 
-        ImGui::PushFont(gui_material_icons_font);
+        //ImGui::PushFont(gui_material_icons_font);
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2.0f, 1.0f));
         ImVec2 bp_icon_btn_size = ImGui::CalcTextSize("X");
         bp_icon_btn_size.x += ImGui::GetStyle().FramePadding.x * 2.0f;
@@ -745,15 +745,17 @@ static void draw_breakpoints_content(void)
         {
            remove = b;
            ImGui::PopStyleVar();
-           ImGui::PopFont();
+           //ImGui::PopFont();
            ImGui::PopID();
            continue;
         }
         if (ImGui::IsItemHovered())
         {
+            ImGui::PopFont();
             ImGui::BeginTooltip();
             ImGui::Text("Remove breakpoint");
             ImGui::EndTooltip();
+            ImGui::PushFont(gui_default_font);
         }
 
         ImGui::SameLine(0, 2);
@@ -764,13 +766,15 @@ static void draw_breakpoints_content(void)
         }
         if (ImGui::IsItemHovered())
         {
+            ImGui::PopFont();
             ImGui::BeginTooltip();
             ImGui::Text(brk->enabled ? "Disable breakpoint" : "Enable breakpoint");
             ImGui::EndTooltip();
+            ImGui::PushFont(gui_default_font);
         }
 
         ImGui::PopStyleVar();
-        ImGui::PopFont();
+        //ImGui::PopFont();
 
         ImGui::SameLine();
         const BreakpointTypeInfo* info = get_breakpoint_type_info(brk->type);

--- a/platforms/shared/desktop/gui_debug_memeditor.cpp
+++ b/platforms/shared/desktop/gui_debug_memeditor.cpp
@@ -66,6 +66,8 @@ MemEditor::MemEditor()
     m_find_bytes_buffer[0] = 0;
     m_find_bytes_last_address = -1;
     m_find_bytes_pattern_len = 0;
+    m_breakpoint_callback = NULL;
+    m_breakpoint_editor = -1;
 }
 
 MemEditor::~MemEditor()
@@ -810,6 +812,29 @@ void MemEditor::DrawContexMenu(int address, bool cell_hovered, bool options)
             if (ImGui::Selectable("Add Watch..."))
             {
                 m_add_watch = true;
+            }
+        }
+
+        if (IsValidPointer(m_breakpoint_callback))
+        {
+            int start = address;
+            int end = address;
+
+            if (m_selection_start >= 0 && m_selection_end >= 0)
+            {
+                int sel_start = MIN(m_selection_start, m_selection_end);
+                int sel_end = MAX(m_selection_start, m_selection_end);
+
+                if (address >= sel_start && address <= sel_end)
+                {
+                    start = sel_start;
+                    end = sel_end;
+                }
+            }
+
+            if (ImGui::MenuItem("Toggle Breakpoint"))
+            {
+                m_breakpoint_callback(m_breakpoint_editor, start, end);
             }
         }
 
@@ -2392,4 +2417,10 @@ void MemEditor::LoadSettings(std::istream& stream)
         stream.read((char*)&watch.format, sizeof(int));
         m_watches.push_back(watch);
     }
+}
+
+void MemEditor::SetBreakpointCallback(ContextMenuBreakpointCallback callback, int editor)
+{
+    m_breakpoint_callback = callback;
+    m_breakpoint_editor = editor;
 }

--- a/platforms/shared/desktop/gui_debug_memeditor.cpp
+++ b/platforms/shared/desktop/gui_debug_memeditor.cpp
@@ -817,23 +817,23 @@ void MemEditor::DrawContexMenu(int address, bool cell_hovered, bool options)
 
         if (IsValidPointer(m_breakpoint_callback))
         {
-            int start = address;
-            int end = address;
-
-            if (m_selection_start >= 0 && m_selection_end >= 0)
-            {
-                int sel_start = MIN(m_selection_start, m_selection_end);
-                int sel_end = MAX(m_selection_start, m_selection_end);
-
-                if (address >= sel_start && address <= sel_end)
-                {
-                    start = sel_start;
-                    end = sel_end;
-                }
-            }
-
             if (ImGui::MenuItem("Toggle Breakpoint"))
             {
+                int start = address;
+                int end = address;
+
+                if (m_selection_start >= 0 && m_selection_end >= 0)
+                {
+                    int sel_start = MIN(m_selection_start, m_selection_end);
+                    int sel_end = MAX(m_selection_start, m_selection_end);
+
+                    if (address >= sel_start && address <= sel_end)
+                    {
+                        start = sel_start;
+                        end = sel_end;
+                    }
+                }
+
                 m_breakpoint_callback(m_breakpoint_editor, start, end);
             }
         }

--- a/platforms/shared/desktop/gui_debug_memeditor.h
+++ b/platforms/shared/desktop/gui_debug_memeditor.h
@@ -26,6 +26,8 @@
 #include <iostream>
 #include "imgui.h"
 
+typedef void (*ContextMenuBreakpointCallback)(int editor, int start, int end);
+
 class MemEditor
 {
 public:
@@ -106,6 +108,7 @@ public:
     int PerformSearch(int op, int compare_type, int compare_value, int data_type);
     std::vector<Search>* GetSearchResults();
     int FindBytesSequence(const char* hex_str, int* out_addresses, int max_results);
+    void SetBreakpointCallback(ContextMenuBreakpointCallback cb, int editor);
 
 private:
     bool IsColumnSeparator(int current_column, int column_count);
@@ -184,6 +187,8 @@ private:
     int m_find_bytes_last_address;
     int m_find_bytes_pattern_len;
     std::vector<int> m_find_bytes_results;
+    ContextMenuBreakpointCallback m_breakpoint_callback;
+    int m_breakpoint_editor;
 };
 
 #endif /* GUI_DEBUG_MEMEDITOR_H */

--- a/platforms/shared/desktop/gui_debug_memory.cpp
+++ b/platforms/shared/desktop/gui_debug_memory.cpp
@@ -634,5 +634,10 @@ static void toggle_memory_breakpoint(int editor, int start, int end)
             cpu->AddBreakpoint(type, start, 0, false, true, false, false);
     }
     else
-        cpu->AddBreakpoint(type, start, end, true, true, false, false);
+    {
+        if (cpu->IsBreakpointRange(type, start, end))
+            cpu->RemoveBreakpointRange(type, start, end);
+        else
+            cpu->AddBreakpoint(type, start, end, true, true, false, false);
+    }
 }

--- a/platforms/shared/desktop/gui_debug_memory.cpp
+++ b/platforms/shared/desktop/gui_debug_memory.cpp
@@ -35,6 +35,7 @@ static char set_value_buffer[5] = { };
 
 static void memory_editor_menu(void);
 static void draw_tabs(void);
+static void toggle_memory_breakpoint(int editor, int start, int end);
 
 void gui_debug_memory_init(void)
 {
@@ -49,6 +50,8 @@ void gui_debug_memory_init(void)
         options.uppercase_hex = config_debug.mem_editor_uppercase_hex[i];
         options.gray_out_zeros = config_debug.mem_editor_gray_out_zeros[i];
         mem_edit[i].SetOptions(options);
+
+        mem_edit[i].SetBreakpointCallback(toggle_memory_breakpoint, i);
     }
 }
 
@@ -575,4 +578,61 @@ void gui_debug_memory_load_settings(std::istream& stream)
     {
         mem_edit[i].LoadSettings(stream);
     }
+}
+
+static void toggle_memory_breakpoint(int editor, int start, int end)
+{
+    HuC6280::GG_Breakpoint_Type type;
+
+    switch (editor)
+    {
+    case MEMORY_EDITOR_RAM:
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM;
+        break;
+
+    case MEMORY_EDITOR_ZERO_PAGE:
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE;
+        start &= 0xFF;
+        break;
+
+    case MEMORY_EDITOR_ROM:
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_ROM;
+        break;
+
+    case MEMORY_EDITOR_CARD_RAM:
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM;
+        break;
+
+    case MEMORY_EDITOR_BACKUP_RAM:
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM;
+        break;
+
+    case MEMORY_EDITOR_PALETTES:
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM;
+        break;
+
+    case MEMORY_EDITOR_VRAM_1:
+    case MEMORY_EDITOR_VRAM_2:
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM;
+        break;
+
+    case MEMORY_EDITOR_CDROM_RAM:
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM;
+        break;
+
+    default:
+        return;
+    }
+
+    HuC6280* cpu = emu_get_core()->GetHuC6280();
+
+    if (start == end)
+    {
+        if (cpu->IsBreakpoint(type, start))
+            cpu->RemoveBreakpoint(type, start);
+        else
+            cpu->AddBreakpoint(type, start, 0, false, true, false, false);
+    }
+    else
+        cpu->AddBreakpoint(type, start, end, true, true, false, false);
 }

--- a/platforms/shared/desktop/mcp/mcp_debug_adapter.cpp
+++ b/platforms/shared/desktop/mcp/mcp_debug_adapter.cpp
@@ -166,7 +166,7 @@ void DebugAdapter::SetBreakpoint(u16 address, int type, bool read, bool write, b
     char buffer[16];
     snprintf(buffer, sizeof(buffer), "%04X", address);
 
-    if (type == HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM && execute && !read && !write)
+    if (type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS && execute && !read && !write)
     {
         cpu->AddBreakpoint(address);
     }
@@ -464,8 +464,8 @@ const char* DebugAdapter::GetBreakpointTypeName(int type)
 {
     switch (type)
     {
-        case HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM:
-            return "ROM/RAM";
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS:
+            return "CPU ADDRESS";
         case HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM:
             return "VRAM";
         case HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM:
@@ -474,6 +474,18 @@ const char* DebugAdapter::GetBreakpointTypeName(int type)
             return "6270 REG";
         case HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER:
             return "6260 REG";
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM:
+            return "WRAM";
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE:
+            return "ZERO PAGE";
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_ROM:
+            return "ROM";
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM:
+            return "CARD RAM";
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM:
+            return "CDROM RAM";
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM:
+            return "BACKUP RAM";
         default:
             return "UNKNOWN";
     }

--- a/platforms/shared/desktop/mcp/mcp_debug_adapter.cpp
+++ b/platforms/shared/desktop/mcp/mcp_debug_adapter.cpp
@@ -174,45 +174,15 @@ bool DebugAdapter::SetBreakpointRange(u32 start_address, u32 end_address, int ty
 bool DebugAdapter::ClearBreakpointByAddress(u32 address, int type, bool range, u32 end_address)
 {
     HuC6280* cpu = m_core->GetHuC6280();
-    std::vector<HuC6280::GG_Breakpoint>* breakpoints = cpu->GetBreakpoints();
-    bool removed = false;
-
-    for (int i = (int)breakpoints->size() - 1; i >= 0; i--)
-    {
-        HuC6280::GG_Breakpoint& bp = (*breakpoints)[i];
-
-        if (bp.type != type)
-            continue;
-
-        if (range)
-        {
-            if (bp.range && bp.address1 == address && bp.address2 == end_address)
-            {
-                breakpoints->erase(breakpoints->begin() + i);
-                removed = true;
-            }
-        }
-        else
-        {
-            if (!bp.range && bp.address1 == address)
-            {
-                breakpoints->erase(breakpoints->begin() + i);
-                removed = true;
-            }
-        }
-    }
-
-    if (removed)
-        cpu->RefreshBreakpointFlags();
-
-    return removed;
+    return range ? cpu->RemoveBreakpointRange(type, address, end_address)
+        : cpu->RemoveBreakpoint(type, address);
 }
 
 std::vector<BreakpointInfo> DebugAdapter::ListBreakpoints()
 {
     std::vector<BreakpointInfo> result;
     HuC6280* cpu = m_core->GetHuC6280();
-    std::vector<HuC6280::GG_Breakpoint>* breakpoints = cpu->GetBreakpoints();
+    const std::vector<HuC6280::GG_Breakpoint>* breakpoints = cpu->GetBreakpoints();
 
     for (const HuC6280::GG_Breakpoint& brk : *breakpoints)
     {

--- a/platforms/shared/desktop/mcp/mcp_debug_adapter.cpp
+++ b/platforms/shared/desktop/mcp/mcp_debug_adapter.cpp
@@ -159,37 +159,23 @@ json DebugAdapter::GetDebugStatus()
     return result;
 }
 
-void DebugAdapter::SetBreakpoint(u16 address, int type, bool read, bool write, bool execute)
+bool DebugAdapter::SetBreakpoint(u32 address, int type, bool read, bool write, bool execute)
 {
     HuC6280* cpu = m_core->GetHuC6280();
-
-    char buffer[16];
-    snprintf(buffer, sizeof(buffer), "%04X", address);
-
-    if (type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS && execute && !read && !write)
-    {
-        cpu->AddBreakpoint(address);
-    }
-    else
-    {
-        cpu->AddBreakpoint(type, buffer, read, write, execute);
-    }
+    return cpu->AddBreakpoint(type, address, 0, false, read, write, execute);
 }
 
-void DebugAdapter::SetBreakpointRange(u16 start_address, u16 end_address, int type, bool read, bool write, bool execute)
+bool DebugAdapter::SetBreakpointRange(u32 start_address, u32 end_address, int type, bool read, bool write, bool execute)
 {
     HuC6280* cpu = m_core->GetHuC6280();
-
-    char buffer[16];
-    snprintf(buffer, sizeof(buffer), "%04X-%04X", start_address, end_address);
-
-    cpu->AddBreakpoint(type, buffer, read, write, execute);
+    return cpu->AddBreakpoint(type, start_address, end_address, true, read, write, execute);
 }
 
-void DebugAdapter::ClearBreakpointByAddress(u16 address, int type, u16 end_address)
+bool DebugAdapter::ClearBreakpointByAddress(u32 address, int type, bool range, u32 end_address)
 {
     HuC6280* cpu = m_core->GetHuC6280();
     std::vector<HuC6280::GG_Breakpoint>* breakpoints = cpu->GetBreakpoints();
+    bool removed = false;
 
     for (int i = (int)breakpoints->size() - 1; i >= 0; i--)
     {
@@ -198,17 +184,28 @@ void DebugAdapter::ClearBreakpointByAddress(u16 address, int type, u16 end_addre
         if (bp.type != type)
             continue;
 
-        if (end_address > 0 && end_address >= address)
+        if (range)
         {
             if (bp.range && bp.address1 == address && bp.address2 == end_address)
+            {
                 breakpoints->erase(breakpoints->begin() + i);
+                removed = true;
+            }
         }
         else
         {
             if (!bp.range && bp.address1 == address)
+            {
                 breakpoints->erase(breakpoints->begin() + i);
+                removed = true;
+            }
         }
     }
+
+    if (removed)
+        cpu->RefreshBreakpointFlags();
+
+    return removed;
 }
 
 std::vector<BreakpointInfo> DebugAdapter::ListBreakpoints()

--- a/platforms/shared/desktop/mcp/mcp_debug_adapter.h
+++ b/platforms/shared/desktop/mcp/mcp_debug_adapter.h
@@ -56,8 +56,8 @@ struct BreakpointInfo
 {
     bool enabled;
     int type;
-    u16 address1;
-    u16 address2;
+    u32 address1;
+    u32 address2;
     bool read;
     bool write;
     bool execute;
@@ -103,9 +103,9 @@ public:
     json RunToAddress(u16 address);
 
     // Breakpoints
-    void SetBreakpoint(u16 address, int type, bool read, bool write, bool execute);
-    void SetBreakpointRange(u16 start_address, u16 end_address, int type, bool read, bool write, bool execute);
-    void ClearBreakpointByAddress(u16 address, int type, u16 end_address = 0);
+    bool SetBreakpoint(u32 address, int type, bool read, bool write, bool execute);
+    bool SetBreakpointRange(u32 start_address, u32 end_address, int type, bool read, bool write, bool execute);
+    bool ClearBreakpointByAddress(u32 address, int type, bool range = false, u32 end_address = 0);
     std::vector<BreakpointInfo> ListBreakpoints();
 
     // Registers

--- a/platforms/shared/desktop/mcp/mcp_server.cpp
+++ b/platforms/shared/desktop/mcp/mcp_server.cpp
@@ -323,7 +323,7 @@ void McpServer::HandleToolsList(const json& request)
             {"properties", {
                 {"address", {
                     {"type", "string"},
-                    {"description", "Logical address hex: '8000', '0x8000', or '$8000'."}
+                    {"description", "Address hex for selected memory area: '8000', '0x8000', or '$8000'."}
                 }},
                 {"memory_area", {
                     {"type", "string"},
@@ -356,11 +356,11 @@ void McpServer::HandleToolsList(const json& request)
             {"properties", {
                 {"start_address", {
                     {"type", "string"},
-                    {"description", "Start logical address hex, e.g. '8000'."}
+                    {"description", "Start address hex for selected memory area, e.g. '8000'."}
                 }},
                 {"end_address", {
                     {"type", "string"},
-                    {"description", "End logical address hex, e.g. '8FFF'."}
+                    {"description", "End address hex for selected memory area, e.g. '8FFF'."}
                 }},
                 {"memory_area", {
                     {"type", "string"},
@@ -393,7 +393,7 @@ void McpServer::HandleToolsList(const json& request)
             {"properties", {
                 {"address", {
                     {"type", "string"},
-                    {"description", "Logical address hex; range removals use this as start."}
+                    {"description", "Address hex for selected memory area; range removals use this as start."}
                 }},
                 {"end_address", {
                     {"type", "string"},
@@ -1527,6 +1527,27 @@ static int GetBreakpointTypeFromString(const std::string& memory_area)
     return HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS; // default
 }
 
+static int GetBreakpointAddressDigits(int type)
+{
+    switch (type)
+    {
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM:
+            return 3;
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER:
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER:
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE:
+            return 2;
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_ROM:
+            return 6;
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM:
+            return 5;
+        case HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM:
+            return 3;
+        default:
+            return 4;
+    }
+}
+
 json McpServer::ExecuteCommand(const std::string& toolName, const json& arguments)
 {
     // Normalize tool name: VS Code converts underscores to dots
@@ -1581,7 +1602,7 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
     else if (normalizedTool == "set_breakpoint")
     {
         std::string addrStr = arguments["address"];
-        u16 address;
+        u32 address;
         if (!parse_hex_with_prefix(addrStr, &address))
             return {{"error", "Invalid address format"}};
 
@@ -1601,14 +1622,16 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
         if (!read && !write && !execute)
             return {{"error", "At least one of read, write, or execute must be true"}};
 
-        m_debugAdapter.SetBreakpoint(address, breakpoint_type, read, write, execute);
+        if (!m_debugAdapter.SetBreakpoint(address, breakpoint_type, read, write, execute))
+            return {{"error", "Breakpoint address is out of range for memory area"}};
+
         return {{"success", true}, {"address", addrStr}, {"memory_area", memory_area}};
     }
     else if (normalizedTool == "set_breakpoint_range")
     {
         std::string startAddrStr = arguments["start_address"];
         std::string endAddrStr = arguments["end_address"];
-        u16 start_address, end_address;
+        u32 start_address, end_address;
 
         if (!parse_hex_with_prefix(startAddrStr, &start_address))
             return {{"error", "Invalid start_address format"}};
@@ -1633,14 +1656,16 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
         if (!read && !write && !execute)
             return {{"error", "At least one of read, write, or execute must be true"}};
 
-        m_debugAdapter.SetBreakpointRange(start_address, end_address, breakpoint_type,
-                                         read, write, execute);
+        if (!m_debugAdapter.SetBreakpointRange(start_address, end_address, breakpoint_type,
+                                              read, write, execute))
+            return {{"error", "Breakpoint range is out of range for memory area"}};
+
         return {{"success", true}, {"start_address", startAddrStr}, {"end_address", endAddrStr}, {"memory_area", memory_area}};
     }
     else if (normalizedTool == "remove_breakpoint")
     {
         std::string addrStr = arguments["address"];
-        u16 address;
+        u32 address;
         if (!parse_hex_with_prefix(addrStr, &address))
             return {{"error", "Invalid address format"}};
 
@@ -1648,16 +1673,20 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
         int breakpoint_type = GetBreakpointTypeFromString(memory_area);
 
         // Check if end_address is provided for range breakpoints
-        u16 end_address = 0;
+        u32 end_address = 0;
+        bool range = false;
         if (arguments.contains("end_address"))
         {
             std::string endAddrStr = arguments["end_address"];
             if (!parse_hex_with_prefix(endAddrStr, &end_address))
                 return {{"error", "Invalid end_address format"}};
+            if (address > end_address)
+                return {{"error", "address must be <= end_address"}};
+            range = true;
         }
 
-        m_debugAdapter.ClearBreakpointByAddress(address, breakpoint_type, end_address);
-        return {{"success", true}, {"address", addrStr}, {"memory_area", memory_area}};
+        bool removed = m_debugAdapter.ClearBreakpointByAddress(address, breakpoint_type, range, end_address);
+        return {{"success", true}, {"removed", removed}, {"address", addrStr}, {"memory_area", memory_area}};
     }
     else if (normalizedTool == "list_breakpoints")
     {
@@ -1670,13 +1699,14 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
             bpObj["type"] = bp.type_name;
 
             std::ostringstream addr_ss;
-            addr_ss << std::hex << std::uppercase << std::setfill('0') << std::setw(4) << bp.address1;
+            int address_digits = GetBreakpointAddressDigits(bp.type);
+            addr_ss << std::hex << std::uppercase << std::setfill('0') << std::setw(address_digits) << bp.address1;
             bpObj["address"] = addr_ss.str();
 
             if (bp.range)
             {
                 std::ostringstream addr2_ss;
-                addr2_ss << std::hex << std::uppercase << std::setfill('0') << std::setw(4) << bp.address2;
+                addr2_ss << std::hex << std::uppercase << std::setfill('0') << std::setw(address_digits) << bp.address2;
                 bpObj["address2"] = addr2_ss.str();
             }
 

--- a/platforms/shared/desktop/mcp/mcp_server.cpp
+++ b/platforms/shared/desktop/mcp/mcp_server.cpp
@@ -1608,7 +1608,8 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
     // Normalize tool name: VS Code converts underscores to dots
     std::string normalizedTool = toolName;
     size_t pos = 0;
-    while ((pos = normalizedTool.find('.', pos)) != std::string::npos) {
+    while ((pos = normalizedTool.find('.', pos)) != std::string::npos)
+    {
         normalizedTool[pos] = '_';
         pos++;
     }

--- a/platforms/shared/desktop/mcp/mcp_server.cpp
+++ b/platforms/shared/desktop/mcp/mcp_server.cpp
@@ -317,7 +317,7 @@ void McpServer::HandleToolsList(const json& request)
     tools.push_back({
         {"name", "set_breakpoint"},
         {"title", "Set Breakpoint"},
-        {"description", "Add execute/read/write breakpoint at logical ROM/RAM, VRAM, palette, VDC, or VCE address."},
+        {"description", "Add execute/read/write breakpoint at CPU address (logical ROM/RAM), VRAM, palette, VDC, VCE, WRAM, ROM, Card RAM or CD RAM address."},
         {"inputSchema", {
             {"type", "object"},
             {"properties", {
@@ -327,8 +327,8 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"memory_area", {
                     {"type", "string"},
-                    {"description", "Memory area: rom_ram (default), vram, palette, huc6270_reg, huc6260_reg."},
-                    {"enum", json::array({"rom_ram", "vram", "palette", "huc6270_reg", "huc6260_reg"})}
+                    {"description", "Memory area: cpu_addr (default), vram, palette, huc6270_reg, huc6260_reg, wram, rom, zp, card_ram, cd_ram, backup_ram"},
+                    {"enum", json::array({"cpu_addr", "vram", "zp", "palette", "huc6270_reg", "huc6260_reg", "wram", "rom", "card_ram", "cd_ram", "backup_ram"})}
                 }},
                 {"read", {
                     {"type", "boolean"},
@@ -340,7 +340,7 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"execute", {
                     {"type", "boolean"},
-                    {"description", "Break on execution; only valid for rom_ram. Default true."}
+                    {"description", "Break on execution. Valid for cpu_addr, rom, card_ram, cd_ram"}
                 }}
             }},
             {"required", json::array({"address"})}
@@ -364,8 +364,8 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"memory_area", {
                     {"type", "string"},
-                    {"description", "Memory area: rom_ram, vram, palette, huc6270_reg, huc6260_reg."},
-                    {"enum", json::array({"rom_ram", "vram", "palette", "huc6270_reg", "huc6260_reg"})}
+                    {"description", "Memory area: cpu_addr, vram, palette, huc6270_reg, huc6260_reg, wram, zp, rom, card_ram, cd_ram, backup_ram"},
+                    {"enum", json::array({"cpu_addr", "vram", "palette", "huc6270_reg", "huc6260_reg", "wram", "zp", "rom", "card_ram", "cd_ram", "backup_ram"})}
                 }},
                 {"read", {
                     {"type", "boolean"},
@@ -377,7 +377,7 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"execute", {
                     {"type", "boolean"},
-                    {"description", "Break on execution; only valid for rom_ram. Default true."}
+                    {"description", "Break on execution; Valid for cpu_addr, rom, card_ram, cd_ram."}
                 }}
             }},
             {"required", json::array({"start_address", "end_address"})}
@@ -401,8 +401,8 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"memory_area", {
                     {"type", "string"},
-                    {"description", "Memory area: rom_ram (default), vram, palette, huc6270_reg, huc6260_reg."},
-                    {"enum", json::array({"rom_ram", "vram", "palette", "huc6270_reg", "huc6260_reg"})}
+                    {"description", "Memory area: cpu_addr (default), vram, palette, huc6270_reg, huc6260_reg, wram, zp, rom, card_ram, cd_ram, backup_ram"},
+                    {"enum", json::array({"cpu_addr", "vram", "palette", "huc6270_reg", "huc6260_reg", "wram", "zp", "rom", "card_ram", "cd_ram", "backup_ram"})}
                 }}
             }},
             {"required", json::array({"address"})}
@@ -1513,12 +1513,18 @@ void McpServer::HandleToolsCall(const json& request)
 
 static int GetBreakpointTypeFromString(const std::string& memory_area)
 {
-    if (memory_area == "rom_ram") return HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM;
+    if (memory_area == "cpu_addr") return HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS;
     if (memory_area == "vram") return HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM;
     if (memory_area == "palette") return HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM;
     if (memory_area == "huc6270_reg") return HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER;
     if (memory_area == "huc6260_reg") return HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER;
-    return HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM; // default
+    if (memory_area == "wram") return HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM;
+    if (memory_area == "zp") return HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE;
+    if (memory_area == "rom") return HuC6280::HuC6280_BREAKPOINT_TYPE_ROM;
+    if (memory_area == "card_ram") return HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM;
+    if (memory_area == "cd_ram") return HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM;
+    if (memory_area == "backup_ram") return HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM;
+    return HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS; // default
 }
 
 json McpServer::ExecuteCommand(const std::string& toolName, const json& arguments)
@@ -1579,14 +1585,17 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
         if (!parse_hex_with_prefix(addrStr, &address))
             return {{"error", "Invalid address format"}};
 
-        std::string memory_area = arguments.value("memory_area", "rom_ram");
+        std::string memory_area = arguments.value("memory_area", "cpu_addr");
         int breakpoint_type = GetBreakpointTypeFromString(memory_area);
 
         bool read = arguments.value("read", false);
         bool write = arguments.value("write", false);
         bool execute = arguments.value("execute", true);
 
-        if (breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM)
+        if (breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS &&
+            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM &&
+            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM &&
+            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM)
             execute = false;
 
         if (!read && !write && !execute)
@@ -1608,14 +1617,17 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
         if (start_address > end_address)
             return {{"error", "start_address must be <= end_address"}};
 
-        std::string memory_area = arguments.value("memory_area", "rom_ram");
+        std::string memory_area = arguments.value("memory_area", "cpu_addr");
         int breakpoint_type = GetBreakpointTypeFromString(memory_area);
 
         bool read = arguments.value("read", false);
         bool write = arguments.value("write", false);
         bool execute = arguments.value("execute", true);
 
-        if (breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM)
+        if (breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS &&
+            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM &&
+            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM &&
+            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM)
             execute = false;
 
         if (!read && !write && !execute)
@@ -1632,7 +1644,7 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
         if (!parse_hex_with_prefix(addrStr, &address))
             return {{"error", "Invalid address format"}};
 
-        std::string memory_area = arguments.value("memory_area", "rom_ram");
+        std::string memory_area = arguments.value("memory_area", "cpu_addr");
         int breakpoint_type = GetBreakpointTypeFromString(memory_area);
 
         // Check if end_address is provided for range breakpoints

--- a/platforms/shared/desktop/mcp/mcp_server.cpp
+++ b/platforms/shared/desktop/mcp/mcp_server.cpp
@@ -327,8 +327,8 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"memory_area", {
                     {"type", "string"},
-                    {"description", "Memory area: cpu_addr (default), vram, palette, huc6270_reg, huc6260_reg, wram, rom, zp, card_ram, cd_ram, backup_ram"},
-                    {"enum", json::array({"cpu_addr", "vram", "zp", "palette", "huc6270_reg", "huc6260_reg", "wram", "rom", "card_ram", "cd_ram", "backup_ram"})}
+                    {"description", "Memory area: cpu_addr (default), rom_ram, vram, palette, huc6270_reg, huc6260_reg, wram, rom, zp, card_ram, cd_ram, backup_ram"},
+                    {"enum", json::array({"cpu_addr", "rom_ram", "vram", "zp", "palette", "huc6270_reg", "huc6260_reg", "wram", "rom", "card_ram", "cd_ram", "backup_ram"})}
                 }},
                 {"read", {
                     {"type", "boolean"},
@@ -340,7 +340,7 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"execute", {
                     {"type", "boolean"},
-                    {"description", "Break on execution. Valid for cpu_addr, rom, card_ram, cd_ram"}
+                    {"description", "Break on execution. Valid for cpu_addr, rom_ram, rom, card_ram, cd_ram"}
                 }}
             }},
             {"required", json::array({"address"})}
@@ -364,8 +364,8 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"memory_area", {
                     {"type", "string"},
-                    {"description", "Memory area: cpu_addr, vram, palette, huc6270_reg, huc6260_reg, wram, zp, rom, card_ram, cd_ram, backup_ram"},
-                    {"enum", json::array({"cpu_addr", "vram", "palette", "huc6270_reg", "huc6260_reg", "wram", "zp", "rom", "card_ram", "cd_ram", "backup_ram"})}
+                    {"description", "Memory area: cpu_addr, rom_ram, vram, palette, huc6270_reg, huc6260_reg, wram, zp, rom, card_ram, cd_ram, backup_ram"},
+                    {"enum", json::array({"cpu_addr", "rom_ram", "vram", "palette", "huc6270_reg", "huc6260_reg", "wram", "zp", "rom", "card_ram", "cd_ram", "backup_ram"})}
                 }},
                 {"read", {
                     {"type", "boolean"},
@@ -377,7 +377,7 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"execute", {
                     {"type", "boolean"},
-                    {"description", "Break on execution; Valid for cpu_addr, rom, card_ram, cd_ram."}
+                    {"description", "Break on execution; Valid for cpu_addr, rom_ram, rom, card_ram, cd_ram."}
                 }}
             }},
             {"required", json::array({"start_address", "end_address"})}
@@ -401,8 +401,8 @@ void McpServer::HandleToolsList(const json& request)
                 }},
                 {"memory_area", {
                     {"type", "string"},
-                    {"description", "Memory area: cpu_addr (default), vram, palette, huc6270_reg, huc6260_reg, wram, zp, rom, card_ram, cd_ram, backup_ram"},
-                    {"enum", json::array({"cpu_addr", "vram", "palette", "huc6270_reg", "huc6260_reg", "wram", "zp", "rom", "card_ram", "cd_ram", "backup_ram"})}
+                    {"description", "Memory area: cpu_addr (default), rom_ram, vram, palette, huc6270_reg, huc6260_reg, wram, zp, rom, card_ram, cd_ram, backup_ram"},
+                    {"enum", json::array({"cpu_addr", "rom_ram", "vram", "palette", "huc6270_reg", "huc6260_reg", "wram", "zp", "rom", "card_ram", "cd_ram", "backup_ram"})}
                 }}
             }},
             {"required", json::array({"address"})}
@@ -1511,20 +1511,75 @@ void McpServer::HandleToolsCall(const json& request)
     m_commandQueue.Push(cmd);
 }
 
-static int GetBreakpointTypeFromString(const std::string& memory_area)
+static bool GetBreakpointTypeFromString(const std::string& memory_area, int& type)
 {
-    if (memory_area == "cpu_addr") return HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS;
-    if (memory_area == "vram") return HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM;
-    if (memory_area == "palette") return HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM;
-    if (memory_area == "huc6270_reg") return HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER;
-    if (memory_area == "huc6260_reg") return HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER;
-    if (memory_area == "wram") return HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM;
-    if (memory_area == "zp") return HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE;
-    if (memory_area == "rom") return HuC6280::HuC6280_BREAKPOINT_TYPE_ROM;
-    if (memory_area == "card_ram") return HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM;
-    if (memory_area == "cd_ram") return HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM;
-    if (memory_area == "backup_ram") return HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM;
-    return HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS; // default
+    if (memory_area == "cpu_addr" || memory_area == "rom_ram")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS;
+        return true;
+    }
+
+    if (memory_area == "vram")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM;
+        return true;
+    }
+
+    if (memory_area == "palette")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM;
+        return true;
+    }
+
+    if (memory_area == "huc6270_reg")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER;
+        return true;
+    }
+
+    if (memory_area == "huc6260_reg")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER;
+        return true;
+    }
+
+    if (memory_area == "wram")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM;
+        return true;
+    }
+
+    if (memory_area == "zp")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE;
+        return true;
+    }
+
+    if (memory_area == "rom")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_ROM;
+        return true;
+    }
+
+    if (memory_area == "card_ram")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM;
+        return true;
+    }
+
+    if (memory_area == "cd_ram")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM;
+        return true;
+    }
+
+    if (memory_area == "backup_ram")
+    {
+        type = HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM;
+        return true;
+    }
+
+    return false;
 }
 
 static int GetBreakpointAddressDigits(int type)
@@ -1607,7 +1662,10 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
             return {{"error", "Invalid address format"}};
 
         std::string memory_area = arguments.value("memory_area", "cpu_addr");
-        int breakpoint_type = GetBreakpointTypeFromString(memory_area);
+        int breakpoint_type = HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS;
+
+        if (!GetBreakpointTypeFromString(memory_area, breakpoint_type))
+            return {{"error", "Invalid memory_area: " + memory_area}};
 
         bool read = arguments.value("read", false);
         bool write = arguments.value("write", false);
@@ -1641,7 +1699,10 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
             return {{"error", "start_address must be <= end_address"}};
 
         std::string memory_area = arguments.value("memory_area", "cpu_addr");
-        int breakpoint_type = GetBreakpointTypeFromString(memory_area);
+        int breakpoint_type = HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS;
+
+        if (!GetBreakpointTypeFromString(memory_area, breakpoint_type))
+            return {{"error", "Invalid memory_area: " + memory_area}};
 
         bool read = arguments.value("read", false);
         bool write = arguments.value("write", false);
@@ -1670,7 +1731,10 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
             return {{"error", "Invalid address format"}};
 
         std::string memory_area = arguments.value("memory_area", "cpu_addr");
-        int breakpoint_type = GetBreakpointTypeFromString(memory_area);
+        int breakpoint_type = HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS;
+
+        if (!GetBreakpointTypeFromString(memory_area, breakpoint_type))
+            return {{"error", "Invalid memory_area: " + memory_area}};
 
         // Check if end_address is provided for range breakpoints
         u32 end_address = 0;

--- a/platforms/shared/desktop/mcp/mcp_server.cpp
+++ b/platforms/shared/desktop/mcp/mcp_server.cpp
@@ -1603,6 +1603,85 @@ static int GetBreakpointAddressDigits(int type)
     }
 }
 
+static bool McpBreakpointAccessSupported(int type, HuC6280::GG_Breakpoint_Access access)
+{
+    if (type < 0 || type >= HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT)
+        return false;
+
+    switch (access)
+    {
+        case HuC6280::HuC6280_BREAKPOINT_ACCESS_READ:
+            return true;
+
+        case HuC6280::HuC6280_BREAKPOINT_ACCESS_WRITE:
+            return type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM;
+
+        case HuC6280::HuC6280_BREAKPOINT_ACCESS_EXECUTE:
+            return type == HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS ||
+                type == HuC6280::HuC6280_BREAKPOINT_TYPE_ROM ||
+                type == HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM ||
+                type == HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM;
+
+        default:
+            return false;
+    }
+}
+
+static const char* GetBreakpointAccessName(HuC6280::GG_Breakpoint_Access access)
+{
+    switch (access)
+    {
+        case HuC6280::HuC6280_BREAKPOINT_ACCESS_READ:
+            return "read";
+        case HuC6280::HuC6280_BREAKPOINT_ACCESS_WRITE:
+            return "write";
+        case HuC6280::HuC6280_BREAKPOINT_ACCESS_EXECUTE:
+            return "execute";
+        default:
+            return "unknown";
+    }
+}
+
+static bool ValidateBreakpointAccess(const std::string& memory_area, int type,
+    HuC6280::GG_Breakpoint_Access access, std::string& error)
+{
+    if (McpBreakpointAccessSupported(type, access))
+        return true;
+
+    error = "Unsupported breakpoint access for memory_area: " + memory_area +
+        " does not support " + GetBreakpointAccessName(access);
+    return false;
+}
+
+static bool ParseBreakpointAccesses(const json& arguments, const std::string& memory_area,
+    int type, bool& read, bool& write, bool& execute, std::string& error)
+{
+    read = arguments.value("read", false);
+    write = arguments.value("write", false);
+    execute = arguments.value("execute", true);
+
+    if (!arguments.contains("execute") &&
+        !McpBreakpointAccessSupported(type, HuC6280::HuC6280_BREAKPOINT_ACCESS_EXECUTE))
+        execute = false;
+
+    if (read && !ValidateBreakpointAccess(memory_area, type, HuC6280::HuC6280_BREAKPOINT_ACCESS_READ, error))
+        return false;
+
+    if (write && !ValidateBreakpointAccess(memory_area, type, HuC6280::HuC6280_BREAKPOINT_ACCESS_WRITE, error))
+        return false;
+
+    if (execute && !ValidateBreakpointAccess(memory_area, type, HuC6280::HuC6280_BREAKPOINT_ACCESS_EXECUTE, error))
+        return false;
+
+    if (!read && !write && !execute)
+    {
+        error = "At least one of read, write, or execute must be true";
+        return false;
+    }
+
+    return true;
+}
+
 json McpServer::ExecuteCommand(const std::string& toolName, const json& arguments)
 {
     // Normalize tool name: VS Code converts underscores to dots
@@ -1668,18 +1747,14 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
         if (!GetBreakpointTypeFromString(memory_area, breakpoint_type))
             return {{"error", "Invalid memory_area: " + memory_area}};
 
-        bool read = arguments.value("read", false);
-        bool write = arguments.value("write", false);
-        bool execute = arguments.value("execute", true);
+        bool read = false;
+        bool write = false;
+        bool execute = false;
+        std::string access_error;
 
-        if (breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS &&
-            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM &&
-            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM &&
-            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM)
-            execute = false;
-
-        if (!read && !write && !execute)
-            return {{"error", "At least one of read, write, or execute must be true"}};
+        if (!ParseBreakpointAccesses(arguments, memory_area, breakpoint_type,
+            read, write, execute, access_error))
+            return {{"error", access_error}};
 
         if (!m_debugAdapter.SetBreakpoint(address, breakpoint_type, read, write, execute))
             return {{"error", "Breakpoint address is out of range for memory area"}};
@@ -1705,18 +1780,14 @@ json McpServer::ExecuteCommand(const std::string& toolName, const json& argument
         if (!GetBreakpointTypeFromString(memory_area, breakpoint_type))
             return {{"error", "Invalid memory_area: " + memory_area}};
 
-        bool read = arguments.value("read", false);
-        bool write = arguments.value("write", false);
-        bool execute = arguments.value("execute", true);
+        bool read = false;
+        bool write = false;
+        bool execute = false;
+        std::string access_error;
 
-        if (breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS &&
-            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_ROM &&
-            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM &&
-            breakpoint_type != HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM)
-            execute = false;
-
-        if (!read && !write && !execute)
-            return {{"error", "At least one of read, write, or execute must be true"}};
+        if (!ParseBreakpointAccesses(arguments, memory_area, breakpoint_type,
+            read, write, execute, access_error))
+            return {{"error", access_error}};
 
         if (!m_debugAdapter.SetBreakpointRange(start_address, end_address, breakpoint_type,
                                               read, write, execute))

--- a/src/common.h
+++ b/src/common.h
@@ -183,6 +183,37 @@ inline bool parse_hex_with_prefix(const std::string& hex_str, T* result)
     return parse_hex_string(str, len, result);
 }
 
+inline bool parse_hex_address(const char* text, u32& value)
+{
+    if (!IsValidPointer(text))
+        return false;
+
+    size_t len = strlen(text);
+    if (len == 0 || len > 8)
+        return false;
+
+    u32 result = 0;
+    for (size_t i = 0; i < len; i++)
+    {
+        char c = text[i];
+        u32 digit = 0;
+
+        if (c >= '0' && c <= '9')
+            digit = c - '0';
+        else if (c >= 'a' && c <= 'f')
+            digit = 0xA + c - 'a';
+        else if (c >= 'A' && c <= 'F')
+            digit = 0xA + c - 'A';
+        else
+            return false;
+
+        result = (result << 4) | digit;
+    }
+
+    value = result;
+    return true;
+}
+
 inline char* strncpy_fit(char* dest, const char* src, size_t dest_size)
 {
     if (dest_size == 0)

--- a/src/common.h
+++ b/src/common.h
@@ -183,37 +183,6 @@ inline bool parse_hex_with_prefix(const std::string& hex_str, T* result)
     return parse_hex_string(str, len, result);
 }
 
-inline bool parse_hex_address(const char* text, u32& value)
-{
-    if (!IsValidPointer(text))
-        return false;
-
-    size_t len = strlen(text);
-    if (len == 0 || len > 8)
-        return false;
-
-    u32 result = 0;
-    for (size_t i = 0; i < len; i++)
-    {
-        char c = text[i];
-        u32 digit = 0;
-
-        if (c >= '0' && c <= '9')
-            digit = c - '0';
-        else if (c >= 'a' && c <= 'f')
-            digit = 0xA + c - 'a';
-        else if (c >= 'A' && c <= 'F')
-            digit = 0xA + c - 'A';
-        else
-            return false;
-
-        result = (result << 4) | digit;
-    }
-
-    value = result;
-    return true;
-}
-
 inline char* strncpy_fit(char* dest, const char* src, size_t dest_size)
 {
     if (dest_size == 0)

--- a/src/huc6260.cpp
+++ b/src/huc6260.cpp
@@ -143,9 +143,10 @@ void HuC6260::Reset()
 
 u8 HuC6260::ReadRegister(u16 address)
 {
-#if !defined(GG_DISABLE_DISASSEMBLER)
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER, address & 0x07, true);
-#endif
+    GG_CHECK_MEMORY_BREAKPOINT(m_huc6280,
+        HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER,
+        address & 0x07,
+        true);
 
     u8 ret = 0xFF;
 
@@ -157,9 +158,10 @@ u8 HuC6260::ReadRegister(u16 address)
             break;
         case 5:
             // Color table data MSB
-#if !defined(GG_DISABLE_DISASSEMBLER)
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM, m_color_table_address, true);
-#endif
+            GG_CHECK_MEMORY_BREAKPOINT(m_huc6280,
+                HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM,
+                m_color_table_address,
+                true);
             ret = 0xFE | ((m_color_table[m_color_table_address] >> 8) & 0x01);
             m_color_table_address = (m_color_table_address + 1) & 0x01FF;
             break;
@@ -170,9 +172,10 @@ u8 HuC6260::ReadRegister(u16 address)
 
 void HuC6260::WriteRegister(u16 address, u8 value)
 {
-#if !defined(GG_DISABLE_DISASSEMBLER)
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER, address & 0x07, false);
-#endif
+    GG_CHECK_MEMORY_BREAKPOINT(m_huc6280,
+        HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER,
+        address & 0x07,
+        false);
 
     switch (address & 0x07)
     {
@@ -236,9 +239,10 @@ void HuC6260::WriteRegister(u16 address, u8 value)
             break;
         case 5:
             // Color table data MSB
-#if !defined(GG_DISABLE_DISASSEMBLER)
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM, m_color_table_address, false);
-#endif
+            GG_CHECK_MEMORY_BREAKPOINT(m_huc6280,
+                HuC6280::HuC6280_BREAKPOINT_TYPE_PALETTE_RAM,
+                m_color_table_address,
+                false);
             m_color_table[m_color_table_address] = (m_color_table[m_color_table_address] & 0x00FF) | ((value & 0x01) << 8);
 
 #if !defined(GG_DISABLE_DISASSEMBLER)

--- a/src/huc6270.cpp
+++ b/src/huc6270.cpp
@@ -196,9 +196,10 @@ u8 HuC6270::ReadRegister(u16 address)
             if (m_pending_memory_read)
                 WaitForVramAccess();
 
-#if !defined(GG_DISABLE_DISASSEMBLER)
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER, m_address_register, true);
-#endif
+            GG_CHECK_MEMORY_BREAKPOINT(m_huc6280,
+                HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER,
+                m_address_register,
+                true);
             u8 ret = m_read_buffer >> 8;
 
             if (m_address_register == HUC6270_REG_VRR)
@@ -227,9 +228,10 @@ void HuC6270::WriteRegister(u16 address, u8 value)
         // Data register (MSB)
         case 3:
         {
-#if !defined(GG_DISABLE_DISASSEMBLER)
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER, m_address_register, false);
-#endif
+            GG_CHECK_MEMORY_BREAKPOINT(m_huc6280,
+                HuC6280::HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER,
+                m_address_register,
+                false);
 
             bool msb = address & 0x01;
 

--- a/src/huc6270_inline.h
+++ b/src/huc6270_inline.h
@@ -202,9 +202,10 @@ INLINE void HuC6270::WaitForVramAccess()
 
 INLINE void HuC6270::ProcessVramRead()
 {
-#if !defined(GG_DISABLE_DISASSEMBLER)
-    m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM, m_register[HUC6270_REG_MARR], true);
-#endif
+    GG_CHECK_MEMORY_BREAKPOINT(m_huc6280,
+        HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM,
+        m_register[HUC6270_REG_MARR],
+        true);
     m_read_buffer = ReadVRAM(m_register[HUC6270_REG_MARR]);
     m_register[HUC6270_REG_MARR] += k_huc6270_read_write_increment[(m_register[HUC6270_REG_CR] >> 11) & 0x03];
     m_pending_memory_read = false;
@@ -219,9 +220,10 @@ INLINE void HuC6270::ProcessVramWrite()
     }
     else
     {
-#if !defined(GG_DISABLE_DISASSEMBLER)
-        m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM, m_register[HUC6270_REG_MAWR], false);
-#endif
+        GG_CHECK_MEMORY_BREAKPOINT(m_huc6280,
+            HuC6280::HuC6280_BREAKPOINT_TYPE_VRAM,
+            m_register[HUC6270_REG_MAWR],
+            false);
         m_vram[m_register[HUC6270_REG_MAWR] & 0x7FFF] = m_register[HUC6270_REG_VWR];
     }
 

--- a/src/huc6280.cpp
+++ b/src/huc6280.cpp
@@ -387,7 +387,7 @@ static bool parse_breakpoint_address_text(const char* text, u32& address1, u32& 
         return true;
     }
 
-    //Range
+    // Range
 
     // Reject multiple dashes.
     if (strchr(dash + 1, '-') != NULL)

--- a/src/huc6280.cpp
+++ b/src/huc6280.cpp
@@ -374,7 +374,7 @@ static bool parse_breakpoint_address_text(const char* text, u32& address1, u32& 
     if (dash == NULL)
     {
         // Single address
-        if (!parse_hex_address(text, address1))
+        if (!parse_hex_string(text, strlen(text), &address1))
             return false;
 
         address2 = 0;
@@ -406,8 +406,8 @@ static bool parse_breakpoint_address_text(const char* text, u32& address1, u32& 
     memcpy(right, dash + 1, right_len);
     right[right_len] = 0;
 
-    if ((!parse_hex_address(left, address1)) ||
-        (!parse_hex_address(right, address2)) ||
+    if ((!parse_hex_string(left, left_len, &address1)) ||
+        (!parse_hex_string(right, right_len, &address2)) ||
         (address1 > address2))
         return false;
 

--- a/src/huc6280.cpp
+++ b/src/huc6280.cpp
@@ -157,11 +157,6 @@ static const u32 k_breakpoint_max_address[HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT
     0xFFFF,   // CD RAM
     0x07FF,   // BRAM
 };
-static_assert(
-    sizeof(k_breakpoint_max_address) / sizeof(k_breakpoint_max_address[0]) ==
-    HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT,
-    "k_breakpoint_max_address has wrong number of BP types compared to GG_Breakpoint_Type"
-);
 
 bool HuC6280::GetBreakpointMaxAddress(const GG_Breakpoint& brk, u32& max_address)
 {

--- a/src/huc6280.cpp
+++ b/src/huc6280.cpp
@@ -669,7 +669,7 @@ void HuC6280::CheckMemoryBreakpoints(int type, u32 address, bool read)
 {
 #if !defined(GG_DISABLE_DISASSEMBLER)
 
-    if (!m_breakpoints_enabled)
+    if (!HasMemoryBreakpoints(type, read))
         return;
 
     for (int i = 0; i < (int)m_breakpoints.size(); i++)

--- a/src/huc6280.cpp
+++ b/src/huc6280.cpp
@@ -46,6 +46,7 @@ HuC6280::HuC6280()
     m_processor_state.TIMER_RELOAD = &m_timer_reload;
     m_processor_state.IDR = &m_interrupt_disable_register;
     m_processor_state.IRR = &m_interrupt_request_register;
+    RefreshBreakpointFlags();
 }
 
 HuC6280::~HuC6280()
@@ -139,51 +140,275 @@ void HuC6280::EnableBreakpoints(bool enable, bool irqs)
 void HuC6280::ResetBreakpoints()
 {
     m_breakpoints.clear();
+    RefreshBreakpointFlags();
 }
 
-bool HuC6280::AddBreakpoint(int type, char* text, bool read, bool write, bool execute)
+static const u32 k_breakpoint_max_address[HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT] =
 {
-    int input_len = (int)strlen(text);
-    GG_Breakpoint brk;
+    0xFFFF,   // CPU Address
+    0x7FFF,   // VRAM
+    0x01FF,   // Palette RAM
+    0x0013,   // HuC6270 Reg
+    0x0006,   // HuC6260 Reg
+    0x7FFF,   // WRAM
+    0x00FF,   // ZP
+    0x27FFFF, // ROM
+    0x2FFFF,  // Card RAM
+    0xFFFF,   // CD RAM
+    0x07FF,   // BRAM
+};
+static_assert(
+    sizeof(k_breakpoint_max_address) / sizeof(k_breakpoint_max_address[0]) ==
+    HuC6280::HuC6280_BREAKPOINT_TYPE_COUNT,
+    "k_breakpoint_max_address has wrong number of BP types compared to GG_Breakpoint_Type"
+);
+
+bool HuC6280::GetBreakpointMaxAddress(const GG_Breakpoint& brk, u32& max_address)
+{
+    if (brk.type < 0 || brk.type >= HuC6280_BREAKPOINT_TYPE_COUNT)
+        return false;
+
+    switch (brk.type)
+    {
+        case HuC6280_BREAKPOINT_TYPE_WRAM:
+        {
+            int size = m_memory->GetWorkingRAMSize();
+            if (size <= 0)
+                return false;
+
+            max_address = (u32)(size - 1);
+            return true;
+        }
+        case HuC6280_BREAKPOINT_TYPE_ROM:
+        {
+            int size = m_memory->GetROMSize();
+            if (size <= 0)
+                return false;
+
+            max_address = (u32)(size - 1);
+            return true;
+        }
+
+        case HuC6280_BREAKPOINT_TYPE_CARD_RAM:
+        {
+            int size = m_memory->GetCardRAMSize();
+            if (size <= 0)
+                return false;
+
+            max_address = (u32)(size - 1);
+            return true;
+        }
+
+        case HuC6280_BREAKPOINT_TYPE_CDROM_RAM:
+        {
+            int size = m_memory->GetCDROMRAMSize();
+            if (size <= 0)
+                return false;
+
+            max_address = (u32)(size - 1);
+            return true;
+        }
+
+        default:
+            max_address = k_breakpoint_max_address[brk.type];
+            return true;
+    }
+}
+
+bool HuC6280::BreakpointAddressValid(const GG_Breakpoint &brk)
+{
+    u32 max_address = 0;
+    if (!GetBreakpointMaxAddress(brk, max_address))
+        return false;
+
+    if (brk.range)
+    {
+        if (brk.address1 > brk.address2)
+            return false;
+
+        if (brk.address1 > max_address || brk.address2 > max_address)
+            return false;
+    }
+    else
+    {
+        if (brk.address1 > max_address)
+            return false;
+    }
+
+    return true;
+}
+
+void HuC6280::RefreshBreakpointFlags()
+{
+    m_has_wram_read_breakpoints = false;
+    m_has_wram_write_breakpoints = false;
+    m_has_zp_read_breakpoints = false;
+    m_has_zp_write_breakpoints = false;
+    m_has_rom_read_breakpoints = false;
+    m_has_rom_exec_breakpoints = false;
+    m_has_card_ram_read_breakpoints = false;
+    m_has_card_ram_write_breakpoints = false;
+    m_has_card_ram_exec_breakpoints = false;
+    m_has_cd_ram_read_breakpoints = false;
+    m_has_cd_ram_write_breakpoints = false;
+    m_has_cd_ram_exec_breakpoints = false;
+    m_has_bram_read_breakpoints = false;
+    m_has_bram_write_breakpoints = false;
+
+    for (long unsigned int i = 0; i < m_breakpoints.size(); i++)
+    {
+        GG_Breakpoint* brk = &m_breakpoints[i];
+
+        if (!brk->enabled)
+            continue;
+
+        switch (brk->type)
+        {
+            case HuC6280_BREAKPOINT_TYPE_WRAM:
+                m_has_wram_read_breakpoints |= brk->read;
+                m_has_wram_write_breakpoints |= brk->write;
+                break;
+
+            case HuC6280_BREAKPOINT_TYPE_ZERO_PAGE:
+                m_has_zp_read_breakpoints |= brk->read;
+                m_has_zp_write_breakpoints |= brk->write;
+                break;
+
+            case HuC6280_BREAKPOINT_TYPE_ROM:
+                m_has_rom_read_breakpoints |= brk->read;
+                m_has_rom_exec_breakpoints |= brk->execute;
+                break;
+
+            case HuC6280_BREAKPOINT_TYPE_CARD_RAM:
+                m_has_card_ram_read_breakpoints |= brk->read;
+                m_has_card_ram_write_breakpoints |= brk->write;
+                m_has_card_ram_exec_breakpoints |= brk->execute;
+                break;
+
+            case HuC6280_BREAKPOINT_TYPE_CDROM_RAM:
+                m_has_cd_ram_read_breakpoints |= brk->read;
+                m_has_cd_ram_write_breakpoints |= brk->write;
+                m_has_cd_ram_exec_breakpoints |= brk->execute;
+                break;
+
+            case HuC6280_BREAKPOINT_TYPE_BACKUP_RAM:
+                m_has_bram_read_breakpoints |= brk->read;
+                m_has_bram_write_breakpoints |= brk->write;
+                break;
+        }
+    }
+
+    m_has_physical_memory_read_breakpoints =
+        m_has_wram_read_breakpoints ||
+        m_has_zp_read_breakpoints ||
+        m_has_rom_read_breakpoints ||
+        m_has_card_ram_read_breakpoints ||
+        m_has_cd_ram_read_breakpoints ||
+        m_has_bram_read_breakpoints;
+
+    m_has_physical_memory_write_breakpoints =
+        m_has_wram_write_breakpoints ||
+        m_has_zp_write_breakpoints ||
+        m_has_card_ram_write_breakpoints ||
+        m_has_cd_ram_write_breakpoints ||
+        m_has_bram_write_breakpoints;
+
+    m_has_physical_memory_exec_breakpoints =
+        m_has_rom_exec_breakpoints ||
+        m_has_card_ram_exec_breakpoints ||
+        m_has_cd_ram_exec_breakpoints;
+}
+
+static bool parse_breakpoint_address_text(const char* text, u32& address1, u32& address2, bool& range)
+{
+    if (!IsValidPointer(text))
+        return false;
+
+    const char* dash = strchr(text, '-');
+
+    if (dash == NULL)
+    {
+        // Single address
+        if (!parse_hex_address(text, address1))
+            return false;
+
+        address2 = 0;
+        range = false;
+        return true;
+    }
+
+    //Range
+
+    // Reject multiple dashes.
+    if (strchr(dash + 1, '-') != NULL)
+        return false;
+
+    size_t left_len = dash - text;
+    size_t right_len = strlen(dash + 1);
+
+    if (left_len == 0 || right_len == 0)
+        return false;
+
+    char left[9];
+    char right[9];
+
+    if (left_len >= sizeof(left) || right_len >= sizeof(right))
+        return false;
+
+    memcpy(left, text, left_len);
+    left[left_len] = 0;
+
+    memcpy(right, dash + 1, right_len);
+    right[right_len] = 0;
+
+    if ((!parse_hex_address(left, address1)) ||
+        (!parse_hex_address(right, address2)) ||
+        (address1 > address2))
+        return false;
+
+    range = true;
+    return true;
+}
+
+bool HuC6280::AddBreakpoint(int type, const char* text, bool read, bool write, bool execute)
+{
+    u32 address1 = 0;
+    u32 address2 = 0;
+    bool range = false;
+
+    if (!parse_breakpoint_address_text(text, address1, address2, range))
+        return false;
+
+    return AddBreakpoint(type, address1, address2, range, read, write, execute);
+}
+
+bool HuC6280::AddBreakpoint(u16 address)
+{
+    return AddBreakpoint(
+        HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS,
+        address, 0, false, false, false, true);
+}
+
+bool HuC6280::AddBreakpoint(int type, u32 address1, u32 address2,
+    bool range, bool read, bool write, bool execute)
+{
+    if (!read && !write && !execute)
+        return false;
+
+    GG_Breakpoint brk{};
     brk.enabled = true;
     brk.type = type;
-    brk.address1 = 0;
-    brk.address2 = 0;
-    brk.range = false;
+    brk.address1 = address1;
+    brk.address2 = range ? address2 : 0;
+    brk.range = range;
     brk.read = read;
     brk.write = write;
     brk.execute = execute;
 
-    if (!read && !write && !execute)
+    if (!BreakpointAddressValid(brk))
         return false;
 
-    if ((input_len == 9) && (text[4] == '-'))
-    {
-        // format: AAAA-BBBB
-        if (parse_hex_string(text, 4, &brk.address1) &&
-            parse_hex_string(text + 5, 4, &brk.address2))
-        {
-            brk.range = true;
-        }
-        else
-        {
-            return false;
-        }
-    }
-    else if ((input_len > 0) && (input_len <= 4))
-    {
-        // format: AAAA
-        if (!parse_hex_string(text, input_len, &brk.address1))
-        {
-            return false;
-        }
-    }
-    else
-    {
-        return false;
-    }
-
-    bool found = false;
+    bool changed = false;
 
     for (long unsigned int b = 0; b < m_breakpoints.size(); b++)
     {
@@ -192,41 +417,48 @@ bool HuC6280::AddBreakpoint(int type, char* text, bool read, bool write, bool ex
         if (item->type != brk.type)
             continue;
 
+        bool same_breakpoint = false;
+
         if (brk.range)
-        {
-            if (item->range && (item->address1 == brk.address1) && (item->address2 == brk.address2))
-            {
-                found = true;
-                break;
-            }
-        }
+            same_breakpoint = item->range && item->address1 == brk.address1 && item->address2 == brk.address2;
         else
-        {
-            if (!item->range && (item->address1 == brk.address1))
-            {
-                found = true;
-                break;
-            }
-        }
+            same_breakpoint = !item->range && item->address1 == brk.address1;
+
+        if (!same_breakpoint)
+            continue;
+
+        bool old_read = item->read;
+        bool old_write = item->write;
+        bool old_execute = item->execute;
+        bool old_enabled = item->enabled;
+
+        item->read |= brk.read;
+        item->write |= brk.write;
+        item->execute |= brk.execute;
+        item->enabled = true;
+
+        changed =
+            item->read != old_read ||
+            item->write != old_write ||
+            item->execute != old_execute ||
+            item->enabled != old_enabled;
+
+        if (changed)
+            RefreshBreakpointFlags();
+
+        return true;
     }
 
-    if (!found)
-        m_breakpoints.push_back(brk);
+    m_breakpoints.push_back(brk);
+    RefreshBreakpointFlags();
 
     return true;
-}
-
-bool HuC6280::AddBreakpoint(u16 address)
-{
-    char text[6];
-    snprintf(text, 6, "%04X", address);
-    return AddBreakpoint(HuC6280_BREAKPOINT_TYPE_ROMRAM, text, false, false, true);
 }
 
 void HuC6280::AddRunToBreakpoint(u16 address)
 {
     m_run_to_breakpoint.enabled = true;
-    m_run_to_breakpoint.type = HuC6280_BREAKPOINT_TYPE_ROMRAM;
+    m_run_to_breakpoint.type = HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS;
     m_run_to_breakpoint.address1 = address;
     m_run_to_breakpoint.address2 = 0;
     m_run_to_breakpoint.range = false;
@@ -236,7 +468,7 @@ void HuC6280::AddRunToBreakpoint(u16 address)
     m_run_to_breakpoint_requested = true;
 }
 
-void HuC6280::RemoveBreakpoint(int type, u16 address)
+void HuC6280::RemoveBreakpoint(int type, u32 address)
 {
     for (long unsigned int b = 0; b < m_breakpoints.size(); b++)
     {
@@ -245,12 +477,13 @@ void HuC6280::RemoveBreakpoint(int type, u16 address)
         if (!item->range && (item->address1 == address) && (item->type == type))
         {
             m_breakpoints.erase(m_breakpoints.begin() + b);
+            RefreshBreakpointFlags();
             break;
         }
     }
 }
 
-bool HuC6280::IsBreakpoint(int type, u16 address)
+bool HuC6280::IsBreakpoint(int type, u32 address)
 {
     for (long unsigned int b = 0; b < m_breakpoints.size(); b++)
     {
@@ -271,7 +504,7 @@ void HuC6280::ClearDisassemblerCallStack()
         m_disassembler_call_stack.pop();
 }
 
-void HuC6280::CheckMemoryBreakpoints(int type, u16 address, bool read)
+void HuC6280::CheckMemoryBreakpoints(int type, u32 address, bool read)
 {
 #if !defined(GG_DISABLE_DISASSEMBLER)
 

--- a/src/huc6280.cpp
+++ b/src/huc6280.cpp
@@ -240,20 +240,8 @@ bool HuC6280::BreakpointAddressValid(const GG_Breakpoint &brk)
 
 void HuC6280::RefreshBreakpointFlags()
 {
-    m_has_wram_read_breakpoints = false;
-    m_has_wram_write_breakpoints = false;
-    m_has_zp_read_breakpoints = false;
-    m_has_zp_write_breakpoints = false;
-    m_has_rom_read_breakpoints = false;
-    m_has_rom_exec_breakpoints = false;
-    m_has_card_ram_read_breakpoints = false;
-    m_has_card_ram_write_breakpoints = false;
-    m_has_card_ram_exec_breakpoints = false;
-    m_has_cd_ram_read_breakpoints = false;
-    m_has_cd_ram_write_breakpoints = false;
-    m_has_cd_ram_exec_breakpoints = false;
-    m_has_bram_read_breakpoints = false;
-    m_has_bram_write_breakpoints = false;
+    memset(m_breakpoint_cache, 0, sizeof(m_breakpoint_cache));
+    memset(m_physical_breakpoint_cache, 0, sizeof(m_physical_breakpoint_cache));
 
     for (long unsigned int i = 0; i < m_breakpoints.size(); i++)
     {
@@ -262,61 +250,123 @@ void HuC6280::RefreshBreakpointFlags()
         if (!brk->enabled)
             continue;
 
-        switch (brk->type)
-        {
-            case HuC6280_BREAKPOINT_TYPE_WRAM:
-                m_has_wram_read_breakpoints |= brk->read;
-                m_has_wram_write_breakpoints |= brk->write;
-                break;
+        if (brk->type < 0 || brk->type >= HuC6280_BREAKPOINT_TYPE_COUNT)
+            continue;
 
-            case HuC6280_BREAKPOINT_TYPE_ZERO_PAGE:
-                m_has_zp_read_breakpoints |= brk->read;
-                m_has_zp_write_breakpoints |= brk->write;
-                break;
+        if (brk->read && BreakpointAccessSupported(brk->type, HuC6280_BREAKPOINT_ACCESS_READ))
+            m_breakpoint_cache[brk->type][HuC6280_BREAKPOINT_ACCESS_READ] = true;
 
-            case HuC6280_BREAKPOINT_TYPE_ROM:
-                m_has_rom_read_breakpoints |= brk->read;
-                m_has_rom_exec_breakpoints |= brk->execute;
-                break;
+        if (brk->write && BreakpointAccessSupported(brk->type, HuC6280_BREAKPOINT_ACCESS_WRITE))
+            m_breakpoint_cache[brk->type][HuC6280_BREAKPOINT_ACCESS_WRITE] = true;
 
-            case HuC6280_BREAKPOINT_TYPE_CARD_RAM:
-                m_has_card_ram_read_breakpoints |= brk->read;
-                m_has_card_ram_write_breakpoints |= brk->write;
-                m_has_card_ram_exec_breakpoints |= brk->execute;
-                break;
-
-            case HuC6280_BREAKPOINT_TYPE_CDROM_RAM:
-                m_has_cd_ram_read_breakpoints |= brk->read;
-                m_has_cd_ram_write_breakpoints |= brk->write;
-                m_has_cd_ram_exec_breakpoints |= brk->execute;
-                break;
-
-            case HuC6280_BREAKPOINT_TYPE_BACKUP_RAM:
-                m_has_bram_read_breakpoints |= brk->read;
-                m_has_bram_write_breakpoints |= brk->write;
-                break;
-        }
+        if (brk->execute && BreakpointAccessSupported(brk->type, HuC6280_BREAKPOINT_ACCESS_EXECUTE))
+            m_breakpoint_cache[brk->type][HuC6280_BREAKPOINT_ACCESS_EXECUTE] = true;
     }
 
-    m_has_physical_memory_read_breakpoints =
-        m_has_wram_read_breakpoints ||
-        m_has_zp_read_breakpoints ||
-        m_has_rom_read_breakpoints ||
-        m_has_card_ram_read_breakpoints ||
-        m_has_cd_ram_read_breakpoints ||
-        m_has_bram_read_breakpoints;
+    m_physical_breakpoint_cache[HuC6280_BREAKPOINT_ACCESS_READ] =
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_WRAM][HuC6280_BREAKPOINT_ACCESS_READ] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_ZERO_PAGE][HuC6280_BREAKPOINT_ACCESS_READ] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_ROM][HuC6280_BREAKPOINT_ACCESS_READ] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_CARD_RAM][HuC6280_BREAKPOINT_ACCESS_READ] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_CDROM_RAM][HuC6280_BREAKPOINT_ACCESS_READ] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_BACKUP_RAM][HuC6280_BREAKPOINT_ACCESS_READ];
 
-    m_has_physical_memory_write_breakpoints =
-        m_has_wram_write_breakpoints ||
-        m_has_zp_write_breakpoints ||
-        m_has_card_ram_write_breakpoints ||
-        m_has_cd_ram_write_breakpoints ||
-        m_has_bram_write_breakpoints;
+    m_physical_breakpoint_cache[HuC6280_BREAKPOINT_ACCESS_WRITE] =
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_WRAM][HuC6280_BREAKPOINT_ACCESS_WRITE] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_ZERO_PAGE][HuC6280_BREAKPOINT_ACCESS_WRITE] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_CARD_RAM][HuC6280_BREAKPOINT_ACCESS_WRITE] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_CDROM_RAM][HuC6280_BREAKPOINT_ACCESS_WRITE] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_BACKUP_RAM][HuC6280_BREAKPOINT_ACCESS_WRITE];
 
-    m_has_physical_memory_exec_breakpoints =
-        m_has_rom_exec_breakpoints ||
-        m_has_card_ram_exec_breakpoints ||
-        m_has_cd_ram_exec_breakpoints;
+    m_physical_breakpoint_cache[HuC6280_BREAKPOINT_ACCESS_EXECUTE] =
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_ROM][HuC6280_BREAKPOINT_ACCESS_EXECUTE] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_CARD_RAM][HuC6280_BREAKPOINT_ACCESS_EXECUTE] ||
+        m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_CDROM_RAM][HuC6280_BREAKPOINT_ACCESS_EXECUTE];
+}
+
+bool HuC6280::BreakpointAccessSupported(int type, GG_Breakpoint_Access access) const
+{
+    if (type < 0 || type >= HuC6280_BREAKPOINT_TYPE_COUNT)
+        return false;
+
+    switch (access)
+    {
+        case HuC6280_BREAKPOINT_ACCESS_READ:
+            return true;
+
+        case HuC6280_BREAKPOINT_ACCESS_WRITE:
+            return type != HuC6280_BREAKPOINT_TYPE_ROM;
+
+        case HuC6280_BREAKPOINT_ACCESS_EXECUTE:
+            return type == HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS ||
+                type == HuC6280_BREAKPOINT_TYPE_ROM ||
+                type == HuC6280_BREAKPOINT_TYPE_CARD_RAM ||
+                type == HuC6280_BREAKPOINT_TYPE_CDROM_RAM;
+
+        default:
+            return false;
+    }
+}
+
+bool HuC6280::BreakpointHasAccess(const GG_Breakpoint& brk, GG_Breakpoint_Access access) const
+{
+    switch (access)
+    {
+        case HuC6280_BREAKPOINT_ACCESS_READ:
+            return brk.read;
+        case HuC6280_BREAKPOINT_ACCESS_WRITE:
+            return brk.write;
+        case HuC6280_BREAKPOINT_ACCESS_EXECUTE:
+            return brk.execute;
+        default:
+            return false;
+    }
+}
+
+void HuC6280::SetBreakpointAccess(GG_Breakpoint& brk, GG_Breakpoint_Access access, bool enabled)
+{
+    switch (access)
+    {
+        case HuC6280_BREAKPOINT_ACCESS_READ:
+            brk.read = enabled;
+            break;
+        case HuC6280_BREAKPOINT_ACCESS_WRITE:
+            brk.write = enabled;
+            break;
+        case HuC6280_BREAKPOINT_ACCESS_EXECUTE:
+            brk.execute = enabled;
+            break;
+        default:
+            break;
+    }
+}
+
+bool HuC6280::BreakpointAccessesValid(const GG_Breakpoint& brk) const
+{
+    bool active = false;
+
+    if (brk.read)
+    {
+        if (!BreakpointAccessSupported(brk.type, HuC6280_BREAKPOINT_ACCESS_READ))
+            return false;
+        active = true;
+    }
+
+    if (brk.write)
+    {
+        if (!BreakpointAccessSupported(brk.type, HuC6280_BREAKPOINT_ACCESS_WRITE))
+            return false;
+        active = true;
+    }
+
+    if (brk.execute)
+    {
+        if (!BreakpointAccessSupported(brk.type, HuC6280_BREAKPOINT_ACCESS_EXECUTE))
+            return false;
+        active = true;
+    }
+
+    return active;
 }
 
 static bool parse_breakpoint_address_text(const char* text, u32& address1, u32& address2, bool& range)
@@ -392,9 +442,6 @@ bool HuC6280::AddBreakpoint(u16 address)
 bool HuC6280::AddBreakpoint(int type, u32 address1, u32 address2,
     bool range, bool read, bool write, bool execute)
 {
-    if (!read && !write && !execute)
-        return false;
-
     GG_Breakpoint brk{};
     brk.enabled = true;
     brk.type = type;
@@ -405,7 +452,7 @@ bool HuC6280::AddBreakpoint(int type, u32 address1, u32 address2,
     brk.write = write;
     brk.execute = execute;
 
-    if (!BreakpointAddressValid(brk))
+    if (!BreakpointAccessesValid(brk) || !BreakpointAddressValid(brk))
         return false;
 
     bool changed = false;
@@ -468,7 +515,7 @@ void HuC6280::AddRunToBreakpoint(u16 address)
     m_run_to_breakpoint_requested = true;
 }
 
-void HuC6280::RemoveBreakpoint(int type, u32 address)
+bool HuC6280::RemoveBreakpoint(int type, u32 address)
 {
     for (long unsigned int b = 0; b < m_breakpoints.size(); b++)
     {
@@ -478,9 +525,93 @@ void HuC6280::RemoveBreakpoint(int type, u32 address)
         {
             m_breakpoints.erase(m_breakpoints.begin() + b);
             RefreshBreakpointFlags();
-            break;
+            return true;
         }
     }
+
+    return false;
+}
+
+bool HuC6280::RemoveBreakpointRange(int type, u32 address1, u32 address2)
+{
+    for (long unsigned int b = 0; b < m_breakpoints.size(); b++)
+    {
+        GG_Breakpoint* item = &m_breakpoints[b];
+
+        if (item->range && item->address1 == address1 && item->address2 == address2 && item->type == type)
+        {
+            m_breakpoints.erase(m_breakpoints.begin() + b);
+            RefreshBreakpointFlags();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool HuC6280::RemoveBreakpointAt(int index)
+{
+    if (index < 0 || index >= (int)m_breakpoints.size())
+        return false;
+
+    m_breakpoints.erase(m_breakpoints.begin() + index);
+    RefreshBreakpointFlags();
+    return true;
+}
+
+bool HuC6280::SetBreakpointEnabled(int index, bool enabled)
+{
+    if (index < 0 || index >= (int)m_breakpoints.size())
+        return false;
+
+    if (m_breakpoints[index].enabled == enabled)
+        return true;
+
+    m_breakpoints[index].enabled = enabled;
+    RefreshBreakpointFlags();
+    return true;
+}
+
+bool HuC6280::ToggleBreakpointAccess(int index, GG_Breakpoint_Access access)
+{
+    if (index < 0 || index >= (int)m_breakpoints.size())
+        return false;
+
+    GG_Breakpoint& brk = m_breakpoints[index];
+
+    if (!BreakpointAccessSupported(brk.type, access))
+        return false;
+
+    bool current = BreakpointHasAccess(brk, access);
+
+    if (!brk.enabled)
+    {
+        brk.enabled = true;
+        SetBreakpointAccess(brk, access, true);
+        RefreshBreakpointFlags();
+        return true;
+    }
+
+    int active_flags = 0;
+
+    for (int i = 0; i < HuC6280_BREAKPOINT_ACCESS_COUNT; i++)
+    {
+        GG_Breakpoint_Access item = (GG_Breakpoint_Access)i;
+        if (BreakpointAccessSupported(brk.type, item) && BreakpointHasAccess(brk, item))
+            active_flags++;
+    }
+
+    if (current && active_flags <= 1)
+    {
+        brk.enabled = false;
+        RefreshBreakpointFlags();
+        return true;
+    }
+
+    SetBreakpointAccess(brk, access, !current);
+
+    RefreshBreakpointFlags();
+    return true;
 }
 
 bool HuC6280::IsBreakpoint(int type, u32 address)
@@ -496,6 +627,36 @@ bool HuC6280::IsBreakpoint(int type, u32 address)
     }
 
     return false;
+}
+
+bool HuC6280::IsBreakpointRange(int type, u32 address1, u32 address2)
+{
+    for (long unsigned int b = 0; b < m_breakpoints.size(); b++)
+    {
+        GG_Breakpoint* item = &m_breakpoints[b];
+
+        if (item->range && item->address1 == address1 && item->address2 == address2 && item->type == type)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void HuC6280::SetBreakpoints(const std::vector<GG_Breakpoint>& breakpoints)
+{
+    m_breakpoints.clear();
+
+    for (long unsigned int i = 0; i < breakpoints.size(); i++)
+    {
+        const GG_Breakpoint& bp = breakpoints[i];
+
+        if (BreakpointAccessesValid(bp) && BreakpointAddressValid(bp))
+            m_breakpoints.push_back(bp);
+    }
+
+    RefreshBreakpointFlags();
 }
 
 void HuC6280::ClearDisassemblerCallStack()

--- a/src/huc6280.h
+++ b/src/huc6280.h
@@ -85,6 +85,14 @@ public:
         HuC6280_BREAKPOINT_TYPE_COUNT
     };
 
+    enum GG_Breakpoint_Access
+    {
+        HuC6280_BREAKPOINT_ACCESS_READ = 0,
+        HuC6280_BREAKPOINT_ACCESS_WRITE,
+        HuC6280_BREAKPOINT_ACCESS_EXECUTE,
+        HuC6280_BREAKPOINT_ACCESS_COUNT
+    };
+
     struct GG_Breakpoint
     {
         bool enabled;
@@ -138,13 +146,18 @@ public:
     bool AddBreakpoint(int type, u32 address1, u32 address2,
         bool range, bool read, bool write, bool execute);
     void AddRunToBreakpoint(u16 address);
-    void RemoveBreakpoint(int type, u32 address);
+    bool RemoveBreakpoint(int type, u32 address);
+    bool RemoveBreakpointRange(int type, u32 address1, u32 address2);
+    bool RemoveBreakpointAt(int index);
+    bool SetBreakpointEnabled(int index, bool enabled);
+    bool ToggleBreakpointAccess(int index, GG_Breakpoint_Access access);
     bool IsBreakpoint(int type, u32 address);
+    bool IsBreakpointRange(int type, u32 address1, u32 address2);
+    void SetBreakpoints(const std::vector<GG_Breakpoint>& breakpoints);
     bool HasPhysicalMemoryBreakpoints(int type, bool read) const;
     bool HasPhysicalMemoryBreakpoints(bool read) const;
     bool HasPhysicalExecuteBreakpoints() const;
-    void RefreshBreakpointFlags();
-    std::vector<GG_Breakpoint>* GetBreakpoints();
+    const std::vector<GG_Breakpoint>* GetBreakpoints() const;
     void ClearDisassemblerCallStack();
     std::stack<GG_CallStackEntry>* GetDisassemblerCallStack();
     void CheckMemoryBreakpoints(int type, u32 address, bool read);
@@ -187,23 +200,8 @@ private:
     u32 m_extra_master_cycles;
     s32 m_debug_next_irq;
     bool m_breakpoints_enabled;
-    bool m_has_wram_read_breakpoints;
-    bool m_has_wram_write_breakpoints;
-    bool m_has_zp_read_breakpoints;
-    bool m_has_zp_write_breakpoints;
-    bool m_has_rom_read_breakpoints;
-    bool m_has_rom_exec_breakpoints;
-    bool m_has_card_ram_read_breakpoints;
-    bool m_has_card_ram_write_breakpoints;
-    bool m_has_card_ram_exec_breakpoints;
-    bool m_has_cd_ram_read_breakpoints;
-    bool m_has_cd_ram_write_breakpoints;
-    bool m_has_cd_ram_exec_breakpoints;
-    bool m_has_bram_read_breakpoints;
-    bool m_has_bram_write_breakpoints;
-    bool m_has_physical_memory_read_breakpoints;
-    bool m_has_physical_memory_write_breakpoints;
-    bool m_has_physical_memory_exec_breakpoints;
+    bool m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_COUNT][HuC6280_BREAKPOINT_ACCESS_COUNT];
+    bool m_physical_breakpoint_cache[HuC6280_BREAKPOINT_ACCESS_COUNT];
     bool m_breakpoints_irq_enabled;
     bool m_cpu_breakpoint_hit;
     bool m_memory_breakpoint_hit;
@@ -224,6 +222,11 @@ private:
     bool BreakpointAddressMatches(HuC6280::GG_Breakpoint* brk, u32 address);
     bool GetBreakpointMaxAddress(const GG_Breakpoint& brk, u32& max_address);
     bool BreakpointAddressValid(const GG_Breakpoint &brk);
+    bool BreakpointAccessSupported(int type, GG_Breakpoint_Access access) const;
+    bool BreakpointAccessesValid(const GG_Breakpoint& brk) const;
+    bool BreakpointHasAccess(const GG_Breakpoint& brk, GG_Breakpoint_Access access) const;
+    void SetBreakpointAccess(GG_Breakpoint& brk, GG_Breakpoint_Access access, bool enabled);
+    void RefreshBreakpointFlags();
     void PushCallStack(u16 src, u16 dest, u16 back, u8 bank);
     void PopCallStack();
 

--- a/src/huc6280.h
+++ b/src/huc6280.h
@@ -154,7 +154,7 @@ public:
     bool IsBreakpoint(int type, u32 address);
     bool IsBreakpointRange(int type, u32 address1, u32 address2);
     void SetBreakpoints(const std::vector<GG_Breakpoint>& breakpoints);
-    bool HasPhysicalMemoryBreakpoints(int type, bool read) const;
+    bool HasMemoryBreakpoints(int type, bool read) const;
     bool HasPhysicalMemoryBreakpoints(bool read) const;
     bool HasPhysicalExecuteBreakpoints() const;
     const std::vector<GG_Breakpoint>* GetBreakpoints() const;
@@ -382,6 +382,20 @@ private:
 
 static const int k_huc6280_speed_divisor[2] = { 12, 3 };
 static const int k_huc6280_timer_divisor = (1024 * 3);
+
+#if !defined(GG_DISABLE_DISASSEMBLER)
+#define GG_CHECK_MEMORY_BREAKPOINT(cpu, type, address, read) \
+    do \
+    { \
+        if ((cpu)->HasMemoryBreakpoints((type), (read))) \
+            (cpu)->CheckMemoryBreakpoints((type), (address), (read)); \
+    } while (0)
+#else
+#define GG_CHECK_MEMORY_BREAKPOINT(cpu, type, address, read) \
+    do \
+    { \
+    } while (0)
+#endif
 
 #include "huc6280_inline.h"
 #include "huc6280_opcodes_inline.h"

--- a/src/huc6280.h
+++ b/src/huc6280.h
@@ -71,11 +71,17 @@ public:
 
     enum GG_Breakpoint_Type
     {
-        HuC6280_BREAKPOINT_TYPE_ROMRAM = 0,
+        HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS = 0,
         HuC6280_BREAKPOINT_TYPE_VRAM,
         HuC6280_BREAKPOINT_TYPE_PALETTE_RAM,
         HuC6280_BREAKPOINT_TYPE_HUC6270_REGISTER,
         HuC6280_BREAKPOINT_TYPE_HUC6260_REGISTER,
+        HuC6280_BREAKPOINT_TYPE_WRAM,
+        HuC6280_BREAKPOINT_TYPE_ZERO_PAGE,
+        HuC6280_BREAKPOINT_TYPE_ROM,
+        HuC6280_BREAKPOINT_TYPE_CARD_RAM,
+        HuC6280_BREAKPOINT_TYPE_CDROM_RAM,
+        HuC6280_BREAKPOINT_TYPE_BACKUP_RAM,
         HuC6280_BREAKPOINT_TYPE_COUNT
     };
 
@@ -83,8 +89,8 @@ public:
     {
         bool enabled;
         int type;
-        u16 address1;
-        u16 address2;
+        u32 address1;
+        u32 address2;
         bool read;
         bool write;
         bool execute;
@@ -127,15 +133,21 @@ public:
     bool MemoryBreakpointHit();
     bool RunToBreakpointHit();
     void ResetBreakpoints();
-    bool AddBreakpoint(int type, char* text, bool read, bool write, bool execute);
+    bool AddBreakpoint(int type, const char* text, bool read, bool write, bool execute);
     bool AddBreakpoint(u16 address);
+    bool AddBreakpoint(int type, u32 address1, u32 address2,
+        bool range, bool read, bool write, bool execute);
     void AddRunToBreakpoint(u16 address);
-    void RemoveBreakpoint(int type, u16 address);
-    bool IsBreakpoint(int type, u16 address);
+    void RemoveBreakpoint(int type, u32 address);
+    bool IsBreakpoint(int type, u32 address);
+    bool HasPhysicalMemoryBreakpoints(int type, bool read) const;
+    bool HasPhysicalMemoryBreakpoints(bool read) const;
+    bool HasPhysicalExecuteBreakpoints() const;
+    void RefreshBreakpointFlags();
     std::vector<GG_Breakpoint>* GetBreakpoints();
     void ClearDisassemblerCallStack();
     std::stack<GG_CallStackEntry>* GetDisassemblerCallStack();
-    void CheckMemoryBreakpoints(int type, u16 address, bool read);
+    void CheckMemoryBreakpoints(int type, u32 address, bool read);
     void SetTraceLogger(TraceLogger* trace_logger);
     void SaveState(std::ostream& stream);
     void LoadState(std::istream& stream);
@@ -175,6 +187,23 @@ private:
     u32 m_extra_master_cycles;
     s32 m_debug_next_irq;
     bool m_breakpoints_enabled;
+    bool m_has_wram_read_breakpoints;
+    bool m_has_wram_write_breakpoints;
+    bool m_has_zp_read_breakpoints;
+    bool m_has_zp_write_breakpoints;
+    bool m_has_rom_read_breakpoints;
+    bool m_has_rom_exec_breakpoints;
+    bool m_has_card_ram_read_breakpoints;
+    bool m_has_card_ram_write_breakpoints;
+    bool m_has_card_ram_exec_breakpoints;
+    bool m_has_cd_ram_read_breakpoints;
+    bool m_has_cd_ram_write_breakpoints;
+    bool m_has_cd_ram_exec_breakpoints;
+    bool m_has_bram_read_breakpoints;
+    bool m_has_bram_write_breakpoints;
+    bool m_has_physical_memory_read_breakpoints;
+    bool m_has_physical_memory_write_breakpoints;
+    bool m_has_physical_memory_exec_breakpoints;
     bool m_breakpoints_irq_enabled;
     bool m_cpu_breakpoint_hit;
     bool m_memory_breakpoint_hit;
@@ -192,6 +221,9 @@ private:
     void ClockHardwareCycles(u32 master_cycles);
 
     void CheckBreakpoints();
+    bool BreakpointAddressMatches(HuC6280::GG_Breakpoint* brk, u32 address);
+    bool GetBreakpointMaxAddress(const GG_Breakpoint& brk, u32& max_address);
+    bool BreakpointAddressValid(const GG_Breakpoint &brk);
     void PushCallStack(u16 src, u16 dest, u16 back, u8 bank);
     void PopCallStack();
 

--- a/src/huc6280_inline.h
+++ b/src/huc6280_inline.h
@@ -492,47 +492,28 @@ INLINE bool HuC6280::RunToBreakpointHit()
     return m_run_to_breakpoint_hit;
 }
 
-INLINE std::vector<HuC6280::GG_Breakpoint>* HuC6280::GetBreakpoints()
+INLINE const std::vector<HuC6280::GG_Breakpoint>* HuC6280::GetBreakpoints() const
 {
     return &m_breakpoints;
 }
 
 INLINE bool HuC6280::HasPhysicalMemoryBreakpoints(bool read) const
 {
-    return read ? m_has_physical_memory_read_breakpoints
-        : m_has_physical_memory_write_breakpoints;
+    return m_breakpoints_enabled &&
+        m_physical_breakpoint_cache[read ? HuC6280_BREAKPOINT_ACCESS_READ : HuC6280_BREAKPOINT_ACCESS_WRITE];
 }
 
 INLINE bool HuC6280::HasPhysicalMemoryBreakpoints(int type, bool read) const
 {
-    switch (type)
-    {
-        case HuC6280_BREAKPOINT_TYPE_WRAM:
-            return read ? m_has_wram_read_breakpoints : m_has_wram_write_breakpoints;
+    if (!m_breakpoints_enabled || type < 0 || type >= HuC6280_BREAKPOINT_TYPE_COUNT)
+        return false;
 
-        case HuC6280_BREAKPOINT_TYPE_ZERO_PAGE:
-            return read ? m_has_zp_read_breakpoints : m_has_zp_write_breakpoints;
-
-        case HuC6280_BREAKPOINT_TYPE_ROM:
-            return read ? m_has_rom_read_breakpoints : false;
-
-        case HuC6280_BREAKPOINT_TYPE_CARD_RAM:
-            return read ? m_has_card_ram_read_breakpoints : m_has_card_ram_write_breakpoints;
-
-        case HuC6280_BREAKPOINT_TYPE_CDROM_RAM:
-            return read ? m_has_cd_ram_read_breakpoints : m_has_cd_ram_write_breakpoints;
-
-        case HuC6280_BREAKPOINT_TYPE_BACKUP_RAM:
-            return read ? m_has_bram_read_breakpoints : m_has_bram_write_breakpoints;
-
-        default:
-            return false;
-    }
+    return m_breakpoint_cache[type][read ? HuC6280_BREAKPOINT_ACCESS_READ : HuC6280_BREAKPOINT_ACCESS_WRITE];
 }
 
 INLINE bool HuC6280::HasPhysicalExecuteBreakpoints() const
 {
-    return m_has_physical_memory_exec_breakpoints;
+    return m_breakpoints_enabled && m_physical_breakpoint_cache[HuC6280_BREAKPOINT_ACCESS_EXECUTE];
 }
 
 INLINE std::stack<HuC6280::GG_CallStackEntry>* HuC6280::GetDisassemblerCallStack()

--- a/src/huc6280_inline.h
+++ b/src/huc6280_inline.h
@@ -497,6 +497,44 @@ INLINE std::vector<HuC6280::GG_Breakpoint>* HuC6280::GetBreakpoints()
     return &m_breakpoints;
 }
 
+INLINE bool HuC6280::HasPhysicalMemoryBreakpoints(bool read) const
+{
+    return read ? m_has_physical_memory_read_breakpoints
+        : m_has_physical_memory_write_breakpoints;
+}
+
+INLINE bool HuC6280::HasPhysicalMemoryBreakpoints(int type, bool read) const
+{
+    switch (type)
+    {
+        case HuC6280_BREAKPOINT_TYPE_WRAM:
+            return read ? m_has_wram_read_breakpoints : m_has_wram_write_breakpoints;
+
+        case HuC6280_BREAKPOINT_TYPE_ZERO_PAGE:
+            return read ? m_has_zp_read_breakpoints : m_has_zp_write_breakpoints;
+
+        case HuC6280_BREAKPOINT_TYPE_ROM:
+            return read ? m_has_rom_read_breakpoints : false;
+
+        case HuC6280_BREAKPOINT_TYPE_CARD_RAM:
+            return read ? m_has_card_ram_read_breakpoints : m_has_card_ram_write_breakpoints;
+
+        case HuC6280_BREAKPOINT_TYPE_CDROM_RAM:
+            return read ? m_has_cd_ram_read_breakpoints : m_has_cd_ram_write_breakpoints;
+
+        case HuC6280_BREAKPOINT_TYPE_BACKUP_RAM:
+            return read ? m_has_bram_read_breakpoints : m_has_bram_write_breakpoints;
+
+        default:
+            return false;
+    }
+}
+
+INLINE bool HuC6280::HasPhysicalExecuteBreakpoints() const
+{
+    return m_has_physical_memory_exec_breakpoints;
+}
+
 INLINE std::stack<HuC6280::GG_CallStackEntry>* HuC6280::GetDisassemblerCallStack()
 {
     return &m_disassembler_call_stack;
@@ -556,30 +594,77 @@ INLINE void HuC6280::CheckBreakpoints()
             continue;
         if (!brk->execute)
             continue;
-        if (brk->type != HuC6280_BREAKPOINT_TYPE_ROMRAM)
-            continue;
 
-        if (brk->range)
+        u32 address = 0;
+        bool valid = false;
+
+        if (brk->type == HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS)
         {
-            if (m_PC.GetValue() >= brk->address1 && m_PC.GetValue() <= brk->address2)
-            {
-                m_cpu_breakpoint_hit = true;
-                m_run_to_breakpoint_requested = false;
-                return;
-            }
+            address = m_PC.GetValue();
+            valid = true;
         }
+        else if (!HasPhysicalExecuteBreakpoints())
+            continue;
         else
-        {
-            if (m_PC.GetValue() == brk->address1)
+            switch (brk->type)
             {
-                m_cpu_breakpoint_hit = true;
-                m_run_to_breakpoint_requested = false;
-                return;
+                case HuC6280_BREAKPOINT_TYPE_ROM:
+                {
+                    valid = m_memory->GetROMPhysicalAddress(m_PC.GetValue(), address);
+                    break;
+                }
+                case HuC6280_BREAKPOINT_TYPE_CARD_RAM:
+                {
+                    u16 pc = m_PC.GetValue();
+                    u8 bank = m_memory->GetBank(pc);
+
+                    if (m_memory->GetBankType(bank) == Memory::MEMORY_BANK_TYPE_CARD_RAM)
+                    {
+                        u32 offset = pc & 0x1FFF;
+                        int size = m_memory->GetCardRAMSize();
+                        if (size > 0)
+                        {
+                            address = ((bank - m_memory->GetCardRAMStart()) * 0x2000) + offset;
+                            address %= size;
+                            valid = true;
+                        }
+                    }
+                    break;
+                }
+                case HuC6280_BREAKPOINT_TYPE_CDROM_RAM:
+                {
+                    u16 pc = m_PC.GetValue();
+                    u8 bank = m_memory->GetBank(pc);
+
+                    if (m_memory->GetBankType(bank) == Memory::MEMORY_BANK_TYPE_CDROM_RAM)
+                    {
+                        u32 offset = pc & 0x1FFF;
+                        address = ((bank - 0x80) * 0x2000) + offset;
+                        valid = true;
+                    }
+                    break;
+                }
+                default:
+                    break;
             }
+
+        if (valid && BreakpointAddressMatches(brk, address))
+        {
+            m_cpu_breakpoint_hit = true;
+            m_run_to_breakpoint_requested = false;
+            return;
         }
     }
 
 #endif
+}
+
+INLINE bool HuC6280::BreakpointAddressMatches(GG_Breakpoint* brk, u32 address)
+{
+    if (brk->range)
+        return address >= brk->address1 && address <= brk->address2;
+
+    return address == brk->address1;
 }
 
 INLINE void HuC6280::DisassembleNextOPCode()

--- a/src/huc6280_inline.h
+++ b/src/huc6280_inline.h
@@ -567,6 +567,49 @@ INLINE void HuC6280::CheckBreakpoints()
     if (!m_breakpoints_enabled)
         return;
 
+    u16 pc = m_PC.GetValue();
+    bool has_physical_execute_breakpoints = HasPhysicalExecuteBreakpoints();
+    bool rom_execute_valid = false;
+    bool card_ram_execute_valid = false;
+    bool cdrom_ram_execute_valid = false;
+    u32 rom_execute_address = 0;
+    u32 card_ram_execute_address = 0;
+    u32 cdrom_ram_execute_address = 0;
+
+    if (has_physical_execute_breakpoints)
+    {
+        bool has_rom_execute_breakpoints = m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_ROM][HuC6280_BREAKPOINT_ACCESS_EXECUTE];
+        bool has_card_ram_execute_breakpoints = m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_CARD_RAM][HuC6280_BREAKPOINT_ACCESS_EXECUTE];
+        bool has_cdrom_ram_execute_breakpoints = m_breakpoint_cache[HuC6280_BREAKPOINT_TYPE_CDROM_RAM][HuC6280_BREAKPOINT_ACCESS_EXECUTE];
+
+        if (has_rom_execute_breakpoints || has_card_ram_execute_breakpoints || has_cdrom_ram_execute_breakpoints)
+        {
+            u8 bank = m_memory->GetBank(pc);
+            u16 offset = pc & 0x1FFF;
+            Memory::MemoryBankType bank_type = m_memory->GetBankType(bank);
+
+            if (has_rom_execute_breakpoints && bank_type == Memory::MEMORY_BANK_TYPE_ROM)
+                rom_execute_valid = m_memory->GetROMPhysicalAddress(bank, offset, rom_execute_address);
+
+            if (has_card_ram_execute_breakpoints && bank_type == Memory::MEMORY_BANK_TYPE_CARD_RAM)
+            {
+                int size = m_memory->GetCardRAMSize();
+                if (size > 0)
+                {
+                    card_ram_execute_address = ((bank - m_memory->GetCardRAMStart()) * 0x2000) + offset;
+                    card_ram_execute_address %= size;
+                    card_ram_execute_valid = true;
+                }
+            }
+
+            if (has_cdrom_ram_execute_breakpoints && bank_type == Memory::MEMORY_BANK_TYPE_CDROM_RAM)
+            {
+                cdrom_ram_execute_address = ((bank - 0x80) * 0x2000) + offset;
+                cdrom_ram_execute_valid = true;
+            }
+        }
+    }
+
     for (int i = 0; i < (int)m_breakpoints.size(); i++)
     {
         GG_Breakpoint* brk = &m_breakpoints[i];
@@ -581,48 +624,30 @@ INLINE void HuC6280::CheckBreakpoints()
 
         if (brk->type == HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS)
         {
-            address = m_PC.GetValue();
+            address = pc;
             valid = true;
         }
-        else if (!HasPhysicalExecuteBreakpoints())
+        else if (!has_physical_execute_breakpoints)
             continue;
         else
             switch (brk->type)
             {
                 case HuC6280_BREAKPOINT_TYPE_ROM:
                 {
-                    valid = m_memory->GetROMPhysicalAddress(m_PC.GetValue(), address);
+                    address = rom_execute_address;
+                    valid = rom_execute_valid;
                     break;
                 }
                 case HuC6280_BREAKPOINT_TYPE_CARD_RAM:
                 {
-                    u16 pc = m_PC.GetValue();
-                    u8 bank = m_memory->GetBank(pc);
-
-                    if (m_memory->GetBankType(bank) == Memory::MEMORY_BANK_TYPE_CARD_RAM)
-                    {
-                        u32 offset = pc & 0x1FFF;
-                        int size = m_memory->GetCardRAMSize();
-                        if (size > 0)
-                        {
-                            address = ((bank - m_memory->GetCardRAMStart()) * 0x2000) + offset;
-                            address %= size;
-                            valid = true;
-                        }
-                    }
+                    address = card_ram_execute_address;
+                    valid = card_ram_execute_valid;
                     break;
                 }
                 case HuC6280_BREAKPOINT_TYPE_CDROM_RAM:
                 {
-                    u16 pc = m_PC.GetValue();
-                    u8 bank = m_memory->GetBank(pc);
-
-                    if (m_memory->GetBankType(bank) == Memory::MEMORY_BANK_TYPE_CDROM_RAM)
-                    {
-                        u32 offset = pc & 0x1FFF;
-                        address = ((bank - 0x80) * 0x2000) + offset;
-                        valid = true;
-                    }
+                    address = cdrom_ram_execute_address;
+                    valid = cdrom_ram_execute_valid;
                     break;
                 }
                 default:

--- a/src/huc6280_inline.h
+++ b/src/huc6280_inline.h
@@ -503,7 +503,7 @@ INLINE bool HuC6280::HasPhysicalMemoryBreakpoints(bool read) const
         m_physical_breakpoint_cache[read ? HuC6280_BREAKPOINT_ACCESS_READ : HuC6280_BREAKPOINT_ACCESS_WRITE];
 }
 
-INLINE bool HuC6280::HasPhysicalMemoryBreakpoints(int type, bool read) const
+INLINE bool HuC6280::HasMemoryBreakpoints(int type, bool read) const
 {
     if (!m_breakpoints_enabled || type < 0 || type >= HuC6280_BREAKPOINT_TYPE_COUNT)
         return false;

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -65,14 +65,19 @@ Media::Media(CdRomMedia* cdrom_media)
     m_preload_cdrom = false;
 
     m_rom_map = new u8*[128];
+    m_rom_bank_offset = new u32[128];
     for (int i = 0; i < 128; i++)
+    {
         InitPointer(m_rom_map[i]);
+        m_rom_bank_offset[i] = 0;
+    }
 }
 
 Media::~Media()
 {
     SafeDeleteArray(m_rom);
     SafeDeleteArray(m_rom_map);
+    SafeDeleteArray(m_rom_bank_offset);
 }
 
 void Media::Init()
@@ -104,7 +109,10 @@ void Media::Reset()
     m_avenue_pad_3_button = GG_KEY_SELECT;
 
     for (int i = 0; i < 128; i++)
+    {
         InitPointer(m_rom_map[i]);
+        m_rom_bank_offset[i] = 0;
+    }
 
     m_cdrom_media->Reset();
 }
@@ -723,6 +731,7 @@ void Media::InitRomMAP()
             int bank = x & 0x1F;
             int bank_address = bank * 0x2000;
             m_rom_map[x] = &rom_ptr[bank_address];
+            m_rom_bank_offset[x] = bank_address;
         }
 
         for(int x = 64; x < 128; x++)
@@ -730,6 +739,7 @@ void Media::InitRomMAP()
             int bank = (x & 0x0F) + 0x20;
             int bank_address = bank * 0x2000;
             m_rom_map[x] = &rom_ptr[bank_address];
+            m_rom_bank_offset[x] = bank_address;
         }
     }
     else if (rom_bank_count == 0x40)
@@ -741,6 +751,7 @@ void Media::InitRomMAP()
             int bank = x & 0x3F;
             int bank_address = bank * 0x2000;
             m_rom_map[x] = &rom_ptr[bank_address];
+            m_rom_bank_offset[x] = bank_address;
         }
 
         for(int x = 64; x < 128; x++)
@@ -748,6 +759,7 @@ void Media::InitRomMAP()
             int bank = (x & 0x1F) + 0x20;
             int bank_address = bank * 0x2000;
             m_rom_map[x] = &rom_ptr[bank_address];
+            m_rom_bank_offset[x] = bank_address;
         }
     }
     else if (rom_bank_count == 0x60)
@@ -759,6 +771,7 @@ void Media::InitRomMAP()
             int bank = x & 0x3F;
             int bank_address = bank * 0x2000;
             m_rom_map[x] = &rom_ptr[bank_address];
+            m_rom_bank_offset[x] = bank_address;
         }
 
         for(int x = 64; x < 128; x++)
@@ -766,6 +779,7 @@ void Media::InitRomMAP()
             int bank = (x & 0x1F) + 0x40;
             int bank_address = bank * 0x2000;
             m_rom_map[x] = &rom_ptr[bank_address];
+            m_rom_bank_offset[x] = bank_address;
         }
     }
     else
@@ -777,6 +791,7 @@ void Media::InitRomMAP()
             int bank = x % rom_bank_count;
             int bank_address = bank * 0x2000;
             m_rom_map[x] = &rom_ptr[bank_address];
+            m_rom_bank_offset[x] = bank_address;
         }
     }
 }

--- a/src/media.h
+++ b/src/media.h
@@ -71,6 +71,7 @@ public:
     const char* GetBiosName(bool syscard);
     u8* GetROM();
     u8** GetROMMap();
+    u32* GetROMBankOffset();
     bool LoadMedia(const char* path);
     bool LoadHuCardFromBuffer(const u8* buffer, int size, const char* path);
     bool LoadCueFromFile(const char* path);
@@ -96,6 +97,7 @@ private:
     CdRomMedia* m_cdrom_media;
     u8* m_rom;
     u8** m_rom_map;
+    u32* m_rom_bank_offset;
     int m_rom_size;
     int m_card_ram_size;
     bool m_ready;

--- a/src/media_inline.h
+++ b/src/media_inline.h
@@ -187,4 +187,9 @@ inline u8** Media::GetROMMap()
     return m_rom_map;
 }
 
+inline u32* Media::GetROMBankOffset()
+{
+    return m_rom_bank_offset;
+}
+
 #endif /* MEDIA_INLINE_H */

--- a/src/memory.h
+++ b/src/memory.h
@@ -64,6 +64,8 @@ public:
     void SetMprTAM(u8 bits, u8 value);
     u8 GetMprTMA(u8 bits);
     u32 GetPhysicalAddress(u16 address);
+    bool GetROMPhysicalAddress(u16 cpu_address, u32& address);
+    bool GetROMPhysicalAddress(u8 bank, u16 offset, u32& address);
     u8 GetBank(u16 address);
     void SetResetValues(int mpr, int wram, int card_ram, int arcade_card);
     GG_Disassembler_Record* GetDisassemblerRecord(u16 address);
@@ -76,6 +78,7 @@ public:
     u8* GetCDROMRAM();
     u8* GetArcadeRAM();
     int GetWorkingRAMSize();
+    int GetROMSize();
     int GetCardRAMSize();
     int GetCardRAMStart();
     int GetCardRAMEnd();
@@ -98,6 +101,9 @@ public:
 
 private:
     void ReloadMemoryMap();
+#if !defined(GG_DISABLE_DISASSEMBLER)
+    void CheckPhysicalMemoryBreakpoints(u8 bank, u32 offset, bool read);
+#endif
 
 private:
     HuC6260* m_huc6260;

--- a/src/memory_inline.h
+++ b/src/memory_inline.h
@@ -511,7 +511,8 @@ INLINE void Memory::UpdateBackupRam(bool enable)
 #if !defined(GG_DISABLE_DISASSEMBLER)
 INLINE void Memory::CheckPhysicalMemoryBreakpoints(u8 bank, u32 offset, bool read)
 {
-    switch (GetBankType(bank)) {
+    switch (GetBankType(bank))
+    {
         case MEMORY_BANK_TYPE_WRAM:
         {
             if (m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE, read))

--- a/src/memory_inline.h
+++ b/src/memory_inline.h
@@ -39,9 +39,7 @@ INLINE u8 Memory::Read(u16 address, bool block_transfer)
     return m_test_memory[address];
 #endif
 
-#if !defined(GG_DISABLE_DISASSEMBLER)
-    m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, address, true);
-#endif
+    GG_CHECK_MEMORY_BREAKPOINT(m_huc6280, HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, address, true);
 
     u8 mpr_index = address >> 13;
     u8 bank = m_mpr[mpr_index];
@@ -208,9 +206,7 @@ INLINE void Memory::Write(u16 address, u8 value, bool block_transfer)
     return;
 #endif
 
-#if !defined(GG_DISABLE_DISASSEMBLER)
-    m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, address, false);
-#endif
+    GG_CHECK_MEMORY_BREAKPOINT(m_huc6280, HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, address, false);
 
     u8 mpr_index = address >> 13;
     u8 bank = m_mpr[mpr_index];
@@ -515,18 +511,15 @@ INLINE void Memory::CheckPhysicalMemoryBreakpoints(u8 bank, u32 offset, bool rea
     {
         case MEMORY_BANK_TYPE_WRAM:
         {
-            if (m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE, read))
+            if (bank == 0xF8 && offset < 0x100)
             {
-                if (bank == 0xF8 && offset < 0x100)
-                {
-                    m_huc6280->CheckMemoryBreakpoints(
-                        HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE,
-                        offset,
-                        read);
-                }
+                GG_CHECK_MEMORY_BREAKPOINT(m_huc6280,
+                    HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE,
+                    offset,
+                    read);
             }
 
-            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM, read))
+            if (!m_huc6280->HasMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM, read))
                 return;
 
             u32 addr = 0;
@@ -535,7 +528,7 @@ INLINE void Memory::CheckPhysicalMemoryBreakpoints(u8 bank, u32 offset, bool rea
             else
                 addr = offset;
 
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM, addr, read);
+            GG_CHECK_MEMORY_BREAKPOINT(m_huc6280, HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM, addr, read);
 
             break;
         }
@@ -545,23 +538,25 @@ INLINE void Memory::CheckPhysicalMemoryBreakpoints(u8 bank, u32 offset, bool rea
             if (!read)
                 return;
 
-            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ROM, read))
+            if (!m_huc6280->HasMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ROM, read))
                 return;
 
             u32 rom_addr = 0;
             if (GetROMPhysicalAddress(bank, offset, rom_addr))
-                m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ROM, rom_addr, true);
+            {
+                GG_CHECK_MEMORY_BREAKPOINT(m_huc6280, HuC6280::HuC6280_BREAKPOINT_TYPE_ROM, rom_addr, true);
+            }
 
             break;
         }
 
         case MEMORY_BANK_TYPE_CDROM_RAM:
         {
-            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM, read))
+            if (!m_huc6280->HasMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM, read))
                 return;
 
             u32 addr = ((bank - 0x80) * 0x2000) + offset;
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM, addr, read);
+            GG_CHECK_MEMORY_BREAKPOINT(m_huc6280, HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM, addr, read);
 
             break;
         }
@@ -569,7 +564,7 @@ INLINE void Memory::CheckPhysicalMemoryBreakpoints(u8 bank, u32 offset, bool rea
 
         case MEMORY_BANK_TYPE_CARD_RAM:
         {
-            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM, read))
+            if (!m_huc6280->HasMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM, read))
                 return;
 
             if (m_card_ram_size == 0)
@@ -578,7 +573,7 @@ INLINE void Memory::CheckPhysicalMemoryBreakpoints(u8 bank, u32 offset, bool rea
             u32 addr = ((bank - m_card_ram_start) * 0x2000) + offset;
             addr %= m_card_ram_size;
 
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM, addr, read);
+            GG_CHECK_MEMORY_BREAKPOINT(m_huc6280, HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM, addr, read);
 
             break;
         }
@@ -586,13 +581,10 @@ INLINE void Memory::CheckPhysicalMemoryBreakpoints(u8 bank, u32 offset, bool rea
 
         case MEMORY_BANK_TYPE_BACKUP_RAM:
         {
-            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM, read))
-                return;
-
             if (offset >= 0x800)
                 return;
 
-            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM, offset, read);
+            GG_CHECK_MEMORY_BREAKPOINT(m_huc6280, HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM, offset, read);
 
             break;
         }

--- a/src/memory_inline.h
+++ b/src/memory_inline.h
@@ -160,6 +160,7 @@ INLINE bool Memory::TryPeek(u16 address, u8 bank, u8* value)
         return false;
 
 #if defined(GG_TESTING)
+    UNUSED(bank);
     *value = m_test_memory[address];
     return true;
 #else

--- a/src/memory_inline.h
+++ b/src/memory_inline.h
@@ -40,12 +40,17 @@ INLINE u8 Memory::Read(u16 address, bool block_transfer)
 #endif
 
 #if !defined(GG_DISABLE_DISASSEMBLER)
-    m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM, address, true);
+    m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, address, true);
 #endif
 
     u8 mpr_index = address >> 13;
     u8 bank = m_mpr[mpr_index];
     u16 offset = address & 0x1FFF;
+
+#if !defined(GG_DISABLE_DISASSEMBLER)
+    if (m_huc6280->HasPhysicalMemoryBreakpoints(true))
+        CheckPhysicalMemoryBreakpoints(bank, offset, true);
+#endif
 
     if (bank != 0xFF)
     {
@@ -204,12 +209,17 @@ INLINE void Memory::Write(u16 address, u8 value, bool block_transfer)
 #endif
 
 #if !defined(GG_DISABLE_DISASSEMBLER)
-    m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ROMRAM, address, false);
+    m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CPU_ADDRESS, address, false);
 #endif
 
     u8 mpr_index = address >> 13;
     u8 bank = m_mpr[mpr_index];
     u16 offset = address & 0x1FFF;
+
+#if !defined(GG_DISABLE_DISASSEMBLER)
+    if (m_huc6280->HasPhysicalMemoryBreakpoints(false))
+        CheckPhysicalMemoryBreakpoints(bank, offset, false);
+#endif
 
     if (IsValidPointer(m_current_mapper) && bank < 0x80)
     {
@@ -313,6 +323,44 @@ INLINE u32 Memory::GetPhysicalAddress(u16 address)
     return (GetBank(address) << 13) | (address & 0x1FFF);
 }
 
+INLINE bool Memory::GetROMPhysicalAddress(u16 cpu_address, u32& rom_address)
+{
+    u8 bank = GetBank(cpu_address);
+    u16 bank_offset = cpu_address & 0x1FFF;
+
+    return GetROMPhysicalAddress(bank, bank_offset, rom_address);
+}
+
+INLINE bool Memory::GetROMPhysicalAddress(u8 bank, u16 bank_offset, u32& rom_address)
+{
+    if (GetBankType(bank) != MEMORY_BANK_TYPE_ROM)
+        return false;
+
+    if (bank >= 128)
+        return false;
+
+    if (IsValidPointer(m_current_mapper) && (m_current_mapper == m_sf2_mapper))
+        return m_sf2_mapper->GetROMPhysicalAddress(bank, bank_offset, rom_address);
+
+    u32* rom_bank_offset = m_media->GetROMBankOffset();
+
+    if (!IsValidPointer(rom_bank_offset))
+        return false;
+
+    int rom_size = m_media->GetROMSize();
+
+    if (rom_size <= 0)
+        return false;
+
+    u32 phys = rom_bank_offset[bank] + bank_offset;
+
+    if (phys >= (u32)rom_size)
+        return false;
+
+    rom_address = phys;
+    return true;
+}
+
 INLINE u8 Memory::GetBank(u16 address)
 {
     return m_mpr[(address >> 13) & 0x07];
@@ -362,6 +410,11 @@ INLINE u8* Memory::GetArcadeRAM()
 INLINE int Memory::GetWorkingRAMSize()
 {
     return m_media->IsSGX() ? 0x8000 : 0x2000;
+}
+
+INLINE int Memory::GetROMSize()
+{
+    return m_media->GetROMSize();
 }
 
 INLINE int Memory::GetCardRAMSize()
@@ -454,5 +507,99 @@ INLINE void Memory::UpdateBackupRam(bool enable)
         m_memory_map[0xF7] = m_unused_memory;
     }
 }
+
+#if !defined(GG_DISABLE_DISASSEMBLER)
+INLINE void Memory::CheckPhysicalMemoryBreakpoints(u8 bank, u32 offset, bool read)
+{
+    switch (GetBankType(bank)) {
+        case MEMORY_BANK_TYPE_WRAM:
+        {
+            if (m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE, read))
+            {
+                if (bank == 0xF8 && offset < 0x100)
+                {
+                    m_huc6280->CheckMemoryBreakpoints(
+                        HuC6280::HuC6280_BREAKPOINT_TYPE_ZERO_PAGE,
+                        offset,
+                        read);
+                }
+            }
+
+            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM, read))
+                return;
+
+            u32 addr = 0;
+            if (m_media->IsSGX())
+                addr = ((bank - 0xF8) * 0x2000) + offset;
+            else
+                addr = offset;
+
+            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_WRAM, addr, read);
+
+            break;
+        }
+
+        case MEMORY_BANK_TYPE_ROM:
+        {
+            if (!read)
+                return;
+
+            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ROM, read))
+                return;
+
+            u32 rom_addr = 0;
+            if (GetROMPhysicalAddress(bank, offset, rom_addr))
+                m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_ROM, rom_addr, true);
+
+            break;
+        }
+
+        case MEMORY_BANK_TYPE_CDROM_RAM:
+        {
+            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM, read))
+                return;
+
+            u32 addr = ((bank - 0x80) * 0x2000) + offset;
+            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CDROM_RAM, addr, read);
+
+            break;
+        }
+
+
+        case MEMORY_BANK_TYPE_CARD_RAM:
+        {
+            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM, read))
+                return;
+
+            if (m_card_ram_size == 0)
+                return;
+
+            u32 addr = ((bank - m_card_ram_start) * 0x2000) + offset;
+            addr %= m_card_ram_size;
+
+            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_CARD_RAM, addr, read);
+
+            break;
+        }
+
+
+        case MEMORY_BANK_TYPE_BACKUP_RAM:
+        {
+            if (!m_huc6280->HasPhysicalMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM, read))
+                return;
+
+            if (offset >= 0x800)
+                return;
+
+            m_huc6280->CheckMemoryBreakpoints(HuC6280::HuC6280_BREAKPOINT_TYPE_BACKUP_RAM, offset, read);
+
+            break;
+        }
+
+        default:
+            break;
+    }
+}
+#endif
 
 #endif /* MEMORY_INLINE_H */

--- a/src/sf2_mapper.cpp
+++ b/src/sf2_mapper.cpp
@@ -50,6 +50,35 @@ u8 SF2Mapper::Peek(u8 bank, u16 address)
     return SF2Mapper::Read(bank, address);
 }
 
+bool SF2Mapper::GetROMPhysicalAddress(u8 bank, u16 address, u32& rom_address)
+{
+    int rom_size = m_media->GetROMSize();
+
+    if (rom_size <= 0)
+        return false;
+
+    u32 phys = 0;
+    if (bank < 0x40)
+    {
+        u32* rom_bank_offset = m_media->GetROMBankOffset();
+
+        if (!IsValidPointer(rom_bank_offset))
+            return false;
+
+        phys = rom_bank_offset[bank] + address;
+    }
+    else
+    {
+        phys = ((u32)bank * 0x2000) + (u32)m_bank_address + address;
+    }
+
+    if (phys >= (u32)rom_size)
+        return false;
+
+    rom_address = phys;
+    return true;
+}
+
 void SF2Mapper::Write(u8 bank, u16 address, u8 value)
 {
     if ((bank == 0x00) && ((address & 0x1FF0) == 0x1FF0))

--- a/src/sf2_mapper.h
+++ b/src/sf2_mapper.h
@@ -33,6 +33,7 @@ public:
     virtual ~SF2Mapper();
     virtual u8 Read(u8 bank, u16 address);
     u8 Peek(u8 bank, u16 address);
+    bool GetROMPhysicalAddress(u8 bank, u16 address, u32& rom_address);
     virtual void Write(u8 bank, u16 address, u8 value);
     virtual void Reset();
     virtual void SaveState(std::ostream& stream);


### PR DESCRIPTION
Hi again.  This one is a tad bigger than the other two.  I've been working on some improvements to the breakpoints system to help my rom hacking endeavors.  Hope you like it.

### Motivation
The way read/write RAM breakpoints works atm is that you can set a breakpoint for these:
- ROM/RAM
- VRAM
- Palette RAM
- HuC6270 Reg
- HuC6260 Reg

In theory you can make a read/write breakpoint for any of WRAM/ROM/CD RAM/Card RAM already, by using the ROM/RAM type and setting a BP at the cpu address pointing at the correct location in the MPR window with the right mapped bank. But there are a couple limitations:
1) When inspecting memory in the memory editor, the physical WRAM/ROM/CD/Card RAM offsets are listed.  If one wants to set a breakpoint, they need to first convert the offset to a CPU visible address using the MPR that has the bank (hopefully) mapped where the byte of interest is located.
2) If a BP is set to a ROM/RAM address, but the game maps a different bank than the bank of interest to the MPR corresponding to that address, it will create false positives. 
3) If one is interested in a specific physical RAM byte, but isn't sure to which MPR the game will map the bank where the byte is located, one has to set breakpoints to all possible MPRs the game may use.  That also gives rise to false positives.
Physical ROM/RAM BPs solve these. 

### New features

- Added physical breakpoint types:
  -   read/write: WRAM, Zero Page, BRAM
  -   read/write/execute: Card RAM, CD RAM
  -   read/execute: ROM

- Physical breakpoints resolve CPU address + MPR bank to backing ROM/RAM offsets, so they follow the actual ROM/RAM location regardless of which MPR maps it.
- Widened breakpoint addresses from u16 to u32, for Card RAM and ROM offsets.
- Support 384KB/512KB/768KB ROMs and SF2 with special mappers
- Added variable-width hex parser for addresses/ranges, e.g. 50, 1000, 50-1FFFF.
- Added per-breakpoint-type address validation.
- Added cached read/write breakpoint flags to avoid physical RAM breakpoint overhead when none are active.
- Adding an existing breakpoint now merges R/W/X flags instead of silently doing nothing.
- Breakpoint list now has clickable R/W/X toggles.
- Add/Toggle breakpoint on address or range from memory editor by clicking "Toggle Breakpoint" in context menu after selecting byte or range of bytes.
- GUI labels and address display updated for new breakpoint types and longer Card RAM addresses.
- Added up/down arrows to re-order the breakpoints in the list.
- Renamed ROM/RAM breakpoint type to CPU_ADDRESS.  This is to avoid confusion with other ROM or RAM breakpoint types.  Existing CPU-visible address behavior is preserved.
- Changed Save/Load Debug Settings to handle the larger addresses.  Bumped magic number to maintain compatibility with old .ggdebug files.
- Changed media load/reset behavior to preserve the breakpoints list.
- MCP/debug adapter breakpoint type names updated for new memory areas.


### Possible future improvements
- Conditional breakpoints
- Add BIOS ROM breakpoints for CD-ROM games? -> would require exposing system card in ROM tab of memory editor
- Error popup with reason why BP couldn't be added if address validation fails?


<img width="3234" height="1780" alt="breakpoints-pr" src="https://github.com/user-attachments/assets/d4fae2ec-f4f5-455e-9986-b843663af61e" />
