### PR TITLE
libchdr: use portable large-file stdio calls

### DIFF
--- a/platforms/shared/dependencies/libchdr/src/libchdr_chd.c
+++ b/platforms/shared/dependencies/libchdr/src/libchdr_chd.c
@@ -3485,8 +3485,8 @@ static uint64_t core_stdio_fsize(core_file *file) {
 	#define core_stdio_fseek_impl _fseeki64
 	#define core_stdio_ftell_impl _ftelli64
 #elif defined(_LARGEFILE_SOURCE) && defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
-	#define core_stdio_fseek_impl fseeko64
-	#define core_stdio_ftell_impl ftello64
+	#define core_stdio_fseek_impl fseeko
+	#define core_stdio_ftell_impl ftello
 #elif defined(__PS3__) && !defined(__PSL1GHT__) || defined(__SWITCH__) || defined(__vita__)
 	#define core_stdio_fseek_impl(x,y,z) fseek(x,(off_t)y,z)
 	#define core_stdio_ftell_impl(x) (off_t)ftell(x)


### PR DESCRIPTION
## Summary

- use `fseeko()` and `ftello()` when `_FILE_OFFSET_BITS=64`
- avoid undeclared `fseeko64()` and `ftello64()` calls on glibc armhf
- retain 64-bit file offsets through the existing feature-test macros

## Background

The bundled libchdr selected the explicit `*64` function names when
`_FILE_OFFSET_BITS=64`. Those names are not declared in the affected armhf
build environment, causing compilation to fail with
`-Werror=implicit-function-declaration`.

The portable interfaces automatically resolve to their 64-bit variants when
`_FILE_OFFSET_BITS=64`.
