### PR TITLE
debian: update package build architectures

### DIFF
--- a/platforms/linux/debian/control
+++ b/platforms/linux/debian/control
@@ -14,7 +14,7 @@ Vcs-Browser: https://github.com/drhelius/Geargrafx
 Vcs-Git: https://github.com/drhelius/Geargrafx.git
 
 Package: geargrafx
-Architecture: any
+Architecture: amd64 amd64v3 arm64 armhf i386
 Depends:
  ${misc:Depends},
  ${shlibs:Depends}


### PR DESCRIPTION
## Summary

- update the Debian package architecture list
- enable amd64, amd64v3, arm64, armhf, and i386 package builds
- align the upstream packaging metadata with the currently maintained build
  targets
